### PR TITLE
Add simple debug view

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Inspired by [Storybook](https://storybook.js.org/) and [Showkase](https://github
 
 # TODO:
 
-- [ ] Debug (#1)
-    - [ ] Dark mode (#1)
+- [x] Debug (#1)
+    - [x] Dark mode (#1)
     - [ ] RTL
     - [ ] Text sizing
     - [ ] Investigate other assistive switches
@@ -48,8 +48,8 @@ Inspired by [Storybook](https://storybook.js.org/) and [Showkase](https://github
         - [ ] Icon
         - [ ] Title
 
-- [ ] Element
-    - [ ] Push
+- [ ] Exhibit
+    - [x] Push
     - [ ] Present
     - [ ] Layout rules (#4)
     - [ ] Parameters (#3)

--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -8,7 +8,10 @@ struct DebugView: View {
     
     @Environment(\.dismiss) var dismiss
     
-    init(parameters: Exhibit.Parameters, preferredColorScheme: Binding<ColorScheme>) {
+    init(
+        parameters: Exhibit.Parameters,
+        preferredColorScheme: Binding<ColorScheme>
+    ) {
         self.parameters = parameters
         _preferredColorScheme = preferredColorScheme
     }

--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// A presented view used to modify accessibility and exhibit parameters.
+struct DebugView: View {
+    @ObservedObject var parameters: Exhibit.Parameters
+    
+    @Binding var preferredColorScheme: ColorScheme
+    
+    @Environment(\.dismiss) var dismiss
+    
+    init(parameters: Exhibit.Parameters, preferredColorScheme: Binding<ColorScheme>) {
+        self.parameters = parameters
+        _preferredColorScheme = preferredColorScheme
+    }
+    
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Accessibility") {
+                    Picker("Color Scheme", selection: $preferredColorScheme) {
+                        Text("Light").tag(ColorScheme.light)
+                        Text("Dark").tag(ColorScheme.dark)
+                    }
+                }
+                
+                Section("Parameters") {
+                    ForEach(Array(parameters.values.keys), id: \.self) { key in
+                        Text("\(key)")
+                    }
+                }
+            }
+            .navigationTitle("Debug")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .preferredColorScheme(preferredColorScheme)
+    }
+}

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -6,7 +6,7 @@ public struct Exhibit: View {
     let view: (Parameters) -> AnyView
     
     @ObservedObject var parameters = Parameters()
-            
+    
     public init<T: View>(name: String, @ViewBuilder _ builder: @escaping (Parameters) -> T) {
         self.name = name
         view = { parameters in AnyView(builder(parameters)) }

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -6,7 +6,7 @@ public struct Exhibit: View {
     let view: (Parameters) -> AnyView
     
     @ObservedObject var parameters = Parameters()
-        
+            
     public init<T: View>(name: String, @ViewBuilder _ builder: @escaping (Parameters) -> T) {
         self.name = name
         view = { parameters in AnyView(builder(parameters)) }
@@ -26,7 +26,7 @@ extension Exhibit: Identifiable {
 
 extension Exhibit {
     public class Parameters: ObservableObject {
-        @Published private var values: [String: Any] = [:]
+        @Published var values: [String: Any] = [:]
         
         public func constant<T>(name: String, defaultValue: T) -> T {
             guard let binding = values[name] else {
@@ -57,4 +57,3 @@ extension Exhibit {
         }
     }
 }
-

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -5,6 +5,10 @@ public struct Exhibition: View {
     let exhibits: [Exhibit]
 
     @State var displayed: AnyHashable?
+    @State var debugViewPresented: Bool = false
+    
+    // MARK: Accessibility
+    @State var preferredColorScheme: ColorScheme = .light
 
     func displayBinding(for id: AnyHashable) -> Binding<Bool> {
         Binding(
@@ -26,11 +30,31 @@ public struct Exhibition: View {
     public var body: some View {
         NavigationView {
             List(exhibits) { exhibit in
-                NavigationLink(exhibit.id, destination: exhibit)
+                NavigationLink(exhibit.id, destination: debuggable(exhibit))
             }
             .navigationTitle("Exhibit")
             .navigationBarTitleDisplayMode(.inline)
         }
+        .preferredColorScheme(preferredColorScheme)
+    }
+    
+    private func debuggable(_ exhibit: Exhibit) -> some View {
+        exhibit
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        debugViewPresented = true
+                    } label: {
+                        Image(systemName: "gear")
+                    }
+                }
+            }
+            .sheet(isPresented: $debugViewPresented) {
+                DebugView(
+                    parameters: exhibit.parameters,
+                    preferredColorScheme: $preferredColorScheme
+                )
+            }
     }
 }
 


### PR DESCRIPTION
Resolves #1

Adds a simple debug view presented as a sheet over top of a given exhibit.

This debug view currently provides a picker for changing the preferred color scheme, and an immutable list of the current exhibits parameters.

![Kapture 2022-02-14 at 11 05 06](https://user-images.githubusercontent.com/609274/153929551-9286d768-3b2c-4743-ada9-b84ccfe98f30.gif)
