### PR TITLE
Add exhibit search

### DIFF
--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -5,6 +5,7 @@ public struct Exhibition: View {
     let exhibits: [Exhibit]
 
     @State var displayed: AnyHashable?
+    @State var searchText = ""
 
     func displayBinding(for id: AnyHashable) -> Binding<Bool> {
         Binding(
@@ -25,11 +26,22 @@ public struct Exhibition: View {
 
     public var body: some View {
         NavigationView {
-            List(exhibits) { exhibit in
+            List(searchResults) { exhibit in
                 NavigationLink(exhibit.id, destination: exhibit)
             }
+            .searchable(text: $searchText)
             .navigationTitle("Exhibit")
             .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+    
+    private var searchResults: [Exhibit] {
+        if searchText.isEmpty {
+            return exhibits
+        } else {
+            return exhibits.filter {
+                $0.id.localizedCaseInsensitiveContains(searchText)
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #2

Adds a search bar to the main exhibit list, allowing filtering of the exhibits.

![Kapture 2022-02-14 at 11 22 31](https://user-images.githubusercontent.com/609274/153931951-9a55a199-816a-4aa8-953c-752b401f72be.gif)

