### PR TITLE
Support debug mutation of some parameters

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D42B337B27BD7E710071C18E /* CustomDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42B337A27BD7E710071C18E /* CustomDatePicker.swift */; };
 		D4B360F927B187EC001F5E20 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B360F827B187EC001F5E20 /* ExampleApp.swift */; };
 		D4B360FB27B187EC001F5E20 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B360FA27B187EC001F5E20 /* ContentView.swift */; };
 		D4B360FD27B187EE001F5E20 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D4B360FC27B187EE001F5E20 /* Assets.xcassets */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		D42B337A27BD7E710071C18E /* CustomDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDatePicker.swift; sourceTree = "<group>"; };
 		D45C4ED327B1CE5000BA8515 /*  */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = ""; sourceTree = "<group>"; };
 		D4B360F527B187EC001F5E20 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4B360F827B187EC001F5E20 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 				D4B360FA27B187EC001F5E20 /* ContentView.swift */,
 				D4B3610827B18839001F5E20 /* CustomButton.swift */,
 				D4C4975227B451950061244C /* CustomToggle.swift */,
+				D42B337A27BD7E710071C18E /* CustomDatePicker.swift */,
 				D4B360F827B187EC001F5E20 /* ExampleApp.swift */,
 				D4E576A227B5988A00A97BB7 /* Exhibition.generated.swift */,
 				D4B360FC27B187EE001F5E20 /* Assets.xcassets */,
@@ -194,6 +197,7 @@
 			files = (
 				D4E576A327B5988A00A97BB7 /* Exhibition.generated.swift in Sources */,
 				D4B360FB27B187EC001F5E20 /* ContentView.swift in Sources */,
+				D42B337B27BD7E710071C18E /* CustomDatePicker.swift in Sources */,
 				D4B360F927B187EC001F5E20 /* ExampleApp.swift in Sources */,
 				D4C4975327B451950061244C /* CustomToggle.swift in Sources */,
 				D4B3610927B18839001F5E20 /* CustomButton.swift in Sources */,

--- a/Example/CustomDatePicker.swift
+++ b/Example/CustomDatePicker.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import Exhibition
+
+struct CustomDatePicker: View {
+    let title: String
+    @Binding var date: Date
+    
+    var body: some View {
+        DatePicker(title, selection: $date)
+    }
+}
+
+struct CustomDatePicker_Previews: ExhibitProvider, PreviewProvider {
+    static var exhibit: Exhibit = Exhibit(name: "CustomDatePicker") { parameters in
+        CustomDatePicker(
+            title: parameters.constant(name: "title", defaultValue: "Title"),
+            date: parameters.binding(name: "date")
+        )
+    }
+}

--- a/Example/Exhibition.generated.swift
+++ b/Example/Exhibition.generated.swift
@@ -6,6 +6,7 @@ import SwiftUI
 public let exhibition = Exhibition(
     exhibits: [
         CustomButton_Previews.exhibit,
+        CustomDatePicker_Previews.exhibit,
         CustomToggle_Previews.exhibit,
     ]
 )

--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ Inspired by [Storybook](https://storybook.js.org/) and [Showkase](https://github
 5. Run `Sourcery` to generate your Exhibition: `sourcery --sources Your/Source/Path --templates Exhibition.swifttemplate --output ./Sources/Generated`
 6. Show `exhibition` in a swift view 
 
+# Custom Parameter views
+
+Exhibition supports a number of types in the parameter list of the debug menu. 
+You can add your own arbitrary types along with a view to modify the parameter, or override the views for existing types.
+Conform to `ParameterView`, and pass the type in via the `.parameterView` modifier on `Exhibition`.
+
+```swift
+struct DoublingStringParameterView: ParameterView {
+    let key: String
+    @Binding var value: String
+    
+    var body: some View {
+        Button(key) {
+            value += value
+        }
+    }
+}
+
+exhibition
+    .parameterView(DoublingStringParameterView.self)
+```
+
 # TODO:
 
 - [x] Debug (#1)
@@ -52,7 +74,7 @@ Inspired by [Storybook](https://storybook.js.org/) and [Showkase](https://github
     - [x] Push
     - [ ] Present
     - [ ] Layout rules (#4)
-    - [ ] Parameters (#3)
+    - [x] Parameters (#3)
     
     - [ ] Code samples (copy-able snippets)
     - [ ] Code documentation (jazzy / swiftdocc)

--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -48,7 +48,7 @@ struct DebugView: View {
     }
     
     private func parameterSort(left: (key: String, value: Any), right: (key: String, value: Any)) -> Bool {
-        return left.key > right.key
+        return left.key < right.key
     }
     
     private func parameterView(parameter: (key: String, value: Any)) -> AnyView? {

--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -7,6 +7,7 @@ struct DebugView: View {
     @Binding var preferredColorScheme: ColorScheme
     
     @Environment(\.dismiss) var dismiss
+    @Environment(\.parameterViews) var parameterViews
     
     init(
         parameters: Exhibit.Parameters,
@@ -27,9 +28,10 @@ struct DebugView: View {
                 }
                 
                 Section("Parameters") {
-                    ForEach(Array(parameters.values.keys), id: \.self) { key in
-                        Text("\(key)")
-                    }
+                    ForEach(
+                        parameters.values.sorted(by: parameterSort), id: \.key,
+                        content: parameterView
+                    )
                 }
             }
             .navigationTitle("Debug")
@@ -43,5 +45,20 @@ struct DebugView: View {
             }
         }
         .preferredColorScheme(preferredColorScheme)
+    }
+    
+    private func parameterSort(left: (key: String, value: Any), right: (key: String, value: Any)) -> Bool {
+        return left.key > right.key
+    }
+    
+    private func parameterView(parameter: (key: String, value: Any)) -> AnyView? {
+        let view = parameterViews
+            .lazy
+            .compactMap { parameterView in
+                parameterView(parameter.key, parameter.value, parameters)
+            }
+            .first
+        
+        return view ?? AnyView(Text(parameter.key))
     }
 }

--- a/Sources/Exhibition/Defaultable.swift
+++ b/Sources/Exhibition/Defaultable.swift
@@ -31,3 +31,7 @@ extension Array: Defaultable {
 extension Dictionary: Defaultable {
     public static var defaultValue: Dictionary<Key, Value> { [:] }
 }
+
+extension Date: Defaultable {
+    public static var defaultValue: Date = .now
+}

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -57,6 +57,9 @@ public struct Exhibition: View {
                     preferredColorScheme: $preferredColorScheme
                 )
             }
+            .parameterView(StringParameterView.self)
+            .parameterView(BoolParameterView.self)
+            .parameterView(IntParameterView.self)
     }
     
     private var searchResults: [Exhibit] {

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -60,6 +60,7 @@ public struct Exhibition: View {
             .parameterView(StringParameterView.self)
             .parameterView(BoolParameterView.self)
             .parameterView(IntParameterView.self)
+            .parameterView(DateParameterView.self)
     }
     
     private var searchResults: [Exhibit] {

--- a/Sources/Exhibition/ParameterView.swift
+++ b/Sources/Exhibition/ParameterView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+// MARK: - Public
+
+/// A view used for manipulating an Exhibit parameter via the Debug view.
+/// See `StringParameterView` for an example implementation.
+public protocol ParameterView: View {
+    associatedtype Value
+    init(key: String, value: Binding<Value>)
+}
+
+extension View {
+    /// Adds or overrides a debug parameter view.
+    /// Intended to be applied to an `Exhibition`
+    ///
+    /// eg: `exhibition.parameterView(CustomParameterView.self)`
+    ///
+    /// - Returns: The existing view.
+    @ViewBuilder public func parameterView<P: ParameterView>(_ parameterView: P.Type) -> some View {
+        self
+            .modifier(ParameterViewModifier(parameterView: erase(parameterView)))
+    }
+}
+
+// MARK: - Internal
+
+/// Type erased parameter view for storage in an array.
+typealias AnyParameterView = (String, Any, Exhibit.Parameters) -> AnyView?
+func erase<P: ParameterView>(_ parameterView: P.Type) -> AnyParameterView {
+    return { name, value, parameters in
+        guard let value = value as? P.Value else {
+            return nil
+        }
+        
+        return AnyView(
+            parameterView.init(
+                key: name,
+                value: parameters.binding(name: name, defaultValue: value)
+            )
+        )
+    }
+}
+
+struct ParameterViewsEnvironmentKey: EnvironmentKey {
+    static var defaultValue: [AnyParameterView] = []
+}
+
+extension EnvironmentValues {
+    var parameterViews: [AnyParameterView] {
+        get { self[ParameterViewsEnvironmentKey.self] }
+        set { self[ParameterViewsEnvironmentKey.self] = newValue }
+    }
+}
+
+// MARK: - Private
+
+private struct ParameterViewModifier: ViewModifier {
+    @Environment(\.parameterViews) var parameterViews
+    
+    let parameterView: AnyParameterView
+    
+    func body(content: Content) -> some View {
+        content
+            .environment(\.parameterViews, parameterViews + [parameterView])
+    }
+}

--- a/Sources/Exhibition/ParameterViews/BoolParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/BoolParameterView.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+extension Toggle: ParameterView where Label == Text {
+    public init(key: String, value: Binding<Bool>) {
+        self.init(key, isOn: value)
+    }
+}
+
+typealias BoolParameterView = Toggle

--- a/Sources/Exhibition/ParameterViews/DateParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/DateParameterView.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+extension DatePicker: ParameterView where Label == Text {
+    public init(key: String, value: Binding<Date>) {
+        self.init(key, selection: value)
+    }
+}
+
+typealias DateParameterView = DatePicker

--- a/Sources/Exhibition/ParameterViews/IntParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/IntParameterView.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+extension Stepper: ParameterView where Label == Text {
+    public init(key: String, value: Binding<Int>) {
+        self.init(key, value: value)
+    }
+}
+
+typealias IntParameterView = Stepper

--- a/Sources/Exhibition/ParameterViews/StringParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/StringParameterView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct StringParameterView: ParameterView {
+    let key: String
+    @Binding var value: String
+    
+    var body: some View {
+        HStack {
+            Text(key)
+            TextField(key, text: $value)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}


### PR DESCRIPTION
Resolves #3 

Adds support for `String`, `Bool`, and `Int` parameter types.

Allows for the consumer to specify custom parameter views, both for overriding types we support, and for adding additional types as well.

![Kapture 2022-02-16 at 10 29 36](https://user-images.githubusercontent.com/609274/154332149-0bf5c398-ba71-490c-944a-80eb2cc510f6.gif)

Please add comments (or tickets after this is merged) for additional types that should be supported by default.
