### PR TITLE
Refactor `Parameters` to `Context` and add logging

### DIFF
--- a/Example/CustomButton.swift
+++ b/Example/CustomButton.swift
@@ -12,9 +12,9 @@ struct CustomButton: View {
 }
 
 struct CustomButton_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit = Exhibit(name: "CustomButton") { parameters in
+    static var exhibit = Exhibit(name: "CustomButton") { context in
         CustomButton(
-            title: parameters.constant(name: "title", defaultValue: "Title")
+            title: context.parameter(name: "title", defaultValue: "Title")
         )
             .previewLayout(.sizeThatFits)
     }

--- a/Example/CustomButton.swift
+++ b/Example/CustomButton.swift
@@ -3,10 +3,11 @@ import SwiftUI
 
 struct CustomButton: View {
     let title: String
+    let action: () -> Void
     
     var body: some View {
         Button(title) {
-            print("Pressed")
+            action()
         }
     }
 }
@@ -15,7 +16,9 @@ struct CustomButton_Previews: ExhibitProvider, PreviewProvider {
     static var exhibit = Exhibit(name: "CustomButton") { context in
         CustomButton(
             title: context.parameter(name: "title", defaultValue: "Title")
-        )
+        ) {
+            context.log("Button Pressed")
+        }
             .previewLayout(.sizeThatFits)
     }
 }

--- a/Example/CustomDatePicker.swift
+++ b/Example/CustomDatePicker.swift
@@ -11,10 +11,10 @@ struct CustomDatePicker: View {
 }
 
 struct CustomDatePicker_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit: Exhibit = Exhibit(name: "CustomDatePicker") { parameters in
+    static var exhibit: Exhibit = Exhibit(name: "CustomDatePicker") { context in
         CustomDatePicker(
-            title: parameters.constant(name: "title", defaultValue: "Title"),
-            date: parameters.binding(name: "date")
+            title: context.parameter(name: "title", defaultValue: "Title"),
+            date: context.parameter(name: "date")
         )
     }
 }

--- a/Example/CustomToggle.swift
+++ b/Example/CustomToggle.swift
@@ -11,10 +11,10 @@ struct CustomToggle: View {
 }
 
 struct CustomToggle_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit = Exhibit(name: "CustomToggle") { parameters in
+    static var exhibit = Exhibit(name: "CustomToggle") { context in
         CustomToggle(
-            title: parameters.constant(name: "title", defaultValue: "Title"),
-            isOn: parameters.binding(name: "isOn")
+            title: context.parameter(name: "title", defaultValue: "Title"),
+            isOn: context.parameter(name: "isOn")
         )
             .previewLayout(.sizeThatFits)
     }

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Inspired by [Storybook](https://storybook.js.org/) and [Showkase](https://github
     import Exhibition
     
     struct Foo_Previews: ExhibitProvider, PreviewProvider {
-        static var exhibit = Exhibit(name: "Foo") { parameters in
+        static var exhibit = Exhibit(name: "Foo") { context in
             Foo(
-                title: parameters.constant(name: "title", defaultValue: "Title"),
-                content: parameters.binding(name: "content")
+                title: context.parameter(name: "title", defaultValue: "Title"),
+                content: context.parameter(name: "content")
             )
             .previewLayout(.sizeThatFits)
         }

--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -33,6 +33,13 @@ struct DebugView: View {
                         )
                     }
                 }
+                
+                if context.log.isEmpty == false {
+                    Section("Log") {
+                        Text(context.log.joined(separator: "\n"))
+                            .textSelection(.enabled)
+                    }
+                }
             }
             .navigationTitle("Debug")
             .navigationBarTitleDisplayMode(.inline)

--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// A presented view used to modify accessibility and exhibit parameters.
 struct DebugView: View {
-    @ObservedObject var parameters: Exhibit.Parameters
+    @ObservedObject var context: Exhibit.Context
     
     @Binding var preferredColorScheme: ColorScheme
     @Binding var layoutDirection: LayoutDirection
@@ -25,10 +25,10 @@ struct DebugView: View {
                     }
                 }
                 
-                if parameters.values.isEmpty == false {
+                if context.parameters.isEmpty == false {
                     Section("Parameters") {
                         ForEach(
-                            parameters.values.sorted(by: parameterSort), id: \.key,
+                            context.parameters.sorted(by: parameterSort), id: \.key,
                             content: parameterView
                         )
                     }
@@ -55,7 +55,7 @@ struct DebugView: View {
         let view = parameterViews
             .lazy
             .compactMap { parameterView in
-                parameterView(parameter.key, parameter.value, parameters)
+                parameterView(parameter.key, parameter.value, context)
             }
             .first
         

--- a/Sources/Exhibition/Exhibit.Context.swift
+++ b/Sources/Exhibition/Exhibit.Context.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+extension Exhibit {
+    public class Context: ObservableObject {
+        @Published var parameters: [String: Any] = [:]
+        
+        public func parameter<T>(name: String, defaultValue: T) -> T {
+            guard let binding = parameters[name] else {
+                parameters[name] = defaultValue
+                return defaultValue
+            }
+            
+            return binding as! T
+        }
+        
+        public func parameter<T>(name: String) -> T where T: Defaultable {
+            parameter(name: name, defaultValue: T.defaultValue)
+        }
+        
+        public func parameter<T>(name: String, defaultValue: T) -> Binding<T> {
+            return Binding(
+                get: { [unowned self] in
+                    self.parameter(name: name, defaultValue: defaultValue)
+                },
+                set: { [unowned self] newValue in
+                    parameters[name] = newValue
+                }
+            )
+        }
+        
+        public func parameter<T>(name: String) -> Binding<T> where T: Defaultable {
+            parameter(name: name, defaultValue: T.defaultValue)
+        }
+    }
+}

--- a/Sources/Exhibition/Exhibit.Context.swift
+++ b/Sources/Exhibition/Exhibit.Context.swift
@@ -3,6 +3,7 @@ import SwiftUI
 extension Exhibit {
     public class Context: ObservableObject {
         @Published var parameters: [String: Any] = [:]
+        @Published var log: [String] = []
         
         public func parameter<T>(name: String, defaultValue: T) -> T {
             guard let binding = parameters[name] else {
@@ -30,6 +31,10 @@ extension Exhibit {
         
         public func parameter<T>(name: String) -> Binding<T> where T: Defaultable {
             parameter(name: name, defaultValue: T.defaultValue)
+        }
+        
+        public func log(_ text: String) {
+            log.append(text)
         }
     }
 }

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -3,17 +3,17 @@ import SwiftUI
 public struct Exhibit: View {
  
     let name: String
-    let view: (Parameters) -> AnyView
+    let view: (Context) -> AnyView
     
-    @ObservedObject var parameters = Parameters()
+    @ObservedObject var context = Context()
     
-    public init<T: View>(name: String, @ViewBuilder _ builder: @escaping (Parameters) -> T) {
+    public init<T: View>(name: String, @ViewBuilder _ builder: @escaping (Context) -> T) {
         self.name = name
-        view = { parameters in AnyView(builder(parameters)) }
+        view = { context in AnyView(builder(context)) }
     }
     
     public var body: some View {
-        view(parameters)
+        view(context)
             .navigationTitle(name)
     }
 }
@@ -24,36 +24,3 @@ extension Exhibit: Identifiable {
     }
 }
 
-extension Exhibit {
-    public class Parameters: ObservableObject {
-        @Published var values: [String: Any] = [:]
-        
-        public func constant<T>(name: String, defaultValue: T) -> T {
-            guard let binding = values[name] else {
-                values[name] = defaultValue
-                return defaultValue
-            }
-            
-            return binding as! T
-        }
-        
-        public func constant<T>(name: String) -> T where T: Defaultable {
-            constant(name: name, defaultValue: T.defaultValue)
-        }
-        
-        public func binding<T>(name: String, defaultValue: T) -> Binding<T> {
-            return Binding(
-                get: { [unowned self] in
-                    self.constant(name: name, defaultValue: defaultValue)
-                },
-                set: { [unowned self] newValue in
-                    values[name] = newValue
-                }
-            )
-        }
-        
-        public func binding<T>(name: String) -> Binding<T> where T: Defaultable {
-            binding(name: name, defaultValue: T.defaultValue)
-        }
-    }
-}

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -48,7 +48,7 @@ public struct Exhibition: View {
             }
             .sheet(isPresented: $debugViewPresented) {
                 DebugView(
-                    parameters: .init(),
+                    context: .init(),
                     preferredColorScheme: $preferredColorScheme,
                     layoutDirection: $layoutDirection
                 )
@@ -71,7 +71,7 @@ public struct Exhibition: View {
             }
             .sheet(isPresented: $debugViewPresented) {
                 DebugView(
-                    parameters: exhibit.parameters,
+                    context: exhibit.context,
                     preferredColorScheme: $preferredColorScheme,
                     layoutDirection: $layoutDirection
                 )
@@ -97,8 +97,8 @@ struct Exhibition_Previews: PreviewProvider {
     static var previews: some View {
         Exhibition(
             exhibits: [
-                .init(name: "Text") { parameters in
-                    Text(parameters.constant(name: "Content", defaultValue: "Text"))
+                .init(name: "Text") { context in
+                    Text(context.parameter(name: "Content", defaultValue: "Text"))
                 }
             ]
         )

--- a/Sources/Exhibition/ParameterView.swift
+++ b/Sources/Exhibition/ParameterView.swift
@@ -25,7 +25,7 @@ extension View {
 // MARK: - Internal
 
 /// Type erased parameter view for storage in an array.
-typealias AnyParameterView = (String, Any, Exhibit.Parameters) -> AnyView?
+typealias AnyParameterView = (String, Any, Exhibit.Context) -> AnyView?
 func erase<P: ParameterView>(_ parameterView: P.Type) -> AnyParameterView {
     return { name, value, parameters in
         guard let value = value as? P.Value else {
@@ -35,7 +35,7 @@ func erase<P: ParameterView>(_ parameterView: P.Type) -> AnyParameterView {
         return AnyView(
             parameterView.init(
                 key: name,
-                value: parameters.binding(name: name, defaultValue: value)
+                value: parameters.parameter(name: name, defaultValue: value)
             )
         )
     }


### PR DESCRIPTION
Resolves #18 

### Rename `Parameters` to `Context`

- Allowing for more functionality such as logging.
- Renames `constant` and `binding` functions to `func parameter(...)`

### Add `func log(_: String)` to `Exhibit.Context`

- Displays logged text in the debug view.

![Kapture 2022-02-17 at 10 19 44](https://user-images.githubusercontent.com/609274/154545574-ec0f7c58-3c6a-4ac9-bf33-5acf673b3e18.gif)

