### PR TITLE
Add optional sections to exhibit list

### DIFF
--- a/Example/CustomDatePicker.swift
+++ b/Example/CustomDatePicker.swift
@@ -11,7 +11,10 @@ struct CustomDatePicker: View {
 }
 
 struct CustomDatePicker_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit: Exhibit = Exhibit(name: "CustomDatePicker") { parameters in
+    static var exhibit = Exhibit(
+        name: "CustomDatePicker",
+        section: "Pickers"
+    ) { parameters in
         CustomDatePicker(
             title: parameters.constant(name: "title", defaultValue: "Title"),
             date: parameters.binding(name: "date")

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Inspired by [Storybook](https://storybook.js.org/) and [Showkase](https://github
     import Exhibition
     
     struct Foo_Previews: ExhibitProvider, PreviewProvider {
-        static var exhibit = Exhibit(name: "Foo") { parameters in
+        static var exhibit = Exhibit(
+            name: "Foo",
+            section: "Bar"
+        ) { parameters in
             Foo(
                 title: parameters.constant(name: "title", defaultValue: "Title"),
                 content: parameters.binding(name: "content")
@@ -64,8 +67,8 @@ exhibition
     - Search top level
     - Search nested
 
-- [ ] Sections (#5)
-    - [ ] Collapsing
+- [x] Sections (#5)
+    - [x] Collapsing
     - [ ] Rows
         - [ ] Icon
         - [ ] Title

--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -28,7 +28,7 @@ struct DebugView: View {
                 if parameters.values.isEmpty == false {
                     Section("Parameters") {
                         ForEach(
-                            parameters.values.sorted(by: parameterSort), id: \.key,
+                            parameters.values.sorted(by: keyAscending), id: \.key,
                             content: parameterView
                         )
                     }
@@ -45,10 +45,6 @@ struct DebugView: View {
             }
         }
         .preferredColorScheme(preferredColorScheme)
-    }
-    
-    private func parameterSort(left: (key: String, value: Any), right: (key: String, value: Any)) -> Bool {
-        return left.key < right.key
     }
     
     private func parameterView(parameter: (key: String, value: Any)) -> AnyView? {

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -3,12 +3,14 @@ import SwiftUI
 public struct Exhibit: View {
  
     let name: String
+    let section: String
     let view: (Parameters) -> AnyView
     
     @ObservedObject var parameters = Parameters()
     
-    public init<T: View>(name: String, @ViewBuilder _ builder: @escaping (Parameters) -> T) {
+    public init<T: View>(name: String, section: String = "", @ViewBuilder _ builder: @escaping (Parameters) -> T) {
         self.name = name
+        self.section = section
         view = { parameters in AnyView(builder(parameters)) }
     }
     

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -11,7 +11,7 @@ public struct Exhibit: View {
     public init<T: View>(name: String, section: String = "", @ViewBuilder _ builder: @escaping (Context) -> T) {
         self.name = name
         self.section = section
-        view = { parameters in AnyView(builder(context)) }
+        view = { context in AnyView(builder(context)) }
     }
     
     public var body: some View {

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -11,6 +11,10 @@ public struct Exhibition: View {
     // MARK: Accessibility
     @State var preferredColorScheme: ColorScheme = .light
     @State var layoutDirection: LayoutDirection = .leftToRight
+    
+    private var sections: [String: [Exhibit]] {
+        Dictionary(grouping: searchResults, by: \.section)
+    }
 
     func displayBinding(for id: AnyHashable) -> Binding<Bool> {
         Binding(
@@ -31,8 +35,18 @@ public struct Exhibition: View {
 
     public var body: some View {
         NavigationView {
-            List(searchResults) { exhibit in
-                NavigationLink(exhibit.id, destination: debuggable(exhibit))
+            List(sections.sorted(by: keyAscending), id: \.key) { section in
+                if section.key.isEmpty {
+                    ForEach(section.value) { exhibit in
+                        NavigationLink(exhibit.id, destination: debuggable(exhibit))
+                    }
+                } else {
+                    Section(section.key) {
+                        ForEach(section.value) { exhibit in
+                            NavigationLink(exhibit.id, destination: debuggable(exhibit))
+                        }
+                    }
+                }
             }
             .searchable(text: $searchText)
             .navigationTitle("Exhibit")
@@ -87,7 +101,8 @@ public struct Exhibition: View {
             return exhibits
         } else {
             return exhibits.filter {
-                $0.id.localizedCaseInsensitiveContains(searchText)
+                $0.id.localizedCaseInsensitiveContains(searchText) ||
+                $0.section.localizedCaseInsensitiveContains(searchText)
             }
         }
     }
@@ -97,28 +112,13 @@ struct Exhibition_Previews: PreviewProvider {
     static var previews: some View {
         Exhibition(
             exhibits: [
-                .init(name: "Text") { parameters in
+                .init(name: "Text", section: "Section 1") { parameters in
+                    Text(parameters.constant(name: "Content", defaultValue: "Text"))
+                },
+                .init(name: "Text2", section: "Section 2") { parameters in
                     Text(parameters.constant(name: "Content", defaultValue: "Text"))
                 }
             ]
         )
-
-        GroupBox {
-            GroupBox {
-                GroupBox {
-                    Text("sgsdgsdgfgdfg")
-                }
-            }
-        }
-        .previewLayout(.sizeThatFits)
-
-        GroupBox {
-            VStack {
-                GroupBox {
-                    Text("sgsdgsdgfgdfg")
-                }
-            }
-        }
-        .previewLayout(.sizeThatFits)
     }
 }

--- a/Sources/Exhibition/Utilities/DictionaryKeySort.swift
+++ b/Sources/Exhibition/Utilities/DictionaryKeySort.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+func keyAscending<Value>(left: (key: String, value: Value), right: (key: String, value: Value)) -> Bool {
+    return left.key < right.key
+}


### PR DESCRIPTION
Resolves #5 

By adding a `section: String` to an exhibit, it will be placed into the appropriate section.

Sections are collapsable, and searchable alongside the exhibits themselves.

Leaving the section as an empty string will insert the exhibit into the top un-collapsable section.

![Simulator Screen Shot - iPhone 12 - 2022-02-17 at 15 34 24](https://user-images.githubusercontent.com/609274/154590107-2ce58b87-d86f-4cbe-a7d4-bbf34eba76e2.png)

