### PR TITLE
Actions/Closures as context parameters

### DIFF
--- a/Example/CustomButton.swift
+++ b/Example/CustomButton.swift
@@ -3,11 +3,11 @@ import SwiftUI
 
 struct CustomButton: View {
     let title: String
-    let action: () -> Void
+    let action: (Date) -> Void
     
     var body: some View {
         Button(title) {
-            action()
+            action(.now)
         }
     }
 }
@@ -15,10 +15,9 @@ struct CustomButton: View {
 struct CustomButton_Previews: ExhibitProvider, PreviewProvider {
     static var exhibit = Exhibit(name: "CustomButton") { context in
         CustomButton(
-            title: context.parameter(name: "title", defaultValue: "Title")
-        ) {
-            context.log("Button Pressed")
-        }
+            title: context.parameter(name: "title", defaultValue: "Title"),
+            action: context.parameter(name: "action")
+        )
             .previewLayout(.sizeThatFits)
     }
 }

--- a/Sources/Exhibition/Exhibit.Context.swift
+++ b/Sources/Exhibition/Exhibit.Context.swift
@@ -38,3 +38,108 @@ extension Exhibit {
         }
     }
 }
+
+// MARK: - Closure Parameters
+
+extension Exhibit.Context {
+    /// A closure parameter with no arguments
+    ///
+    /// EG: `action: () -> Void`
+    ///
+    /// - Parameter name: The name of the parameter
+    /// - Returns: A closure to be executed by the view.
+    public func parameter(name: String) -> () -> Void {
+        let parameter = closureParameter(
+            name: name,
+            signature: "() -> Void"
+        )
+
+        return { [unowned self] in
+            parameter.wrappedValue.callCount += 1
+            self.log("\(name): ())")
+        }
+    }
+    
+    /// A closure parameter with a single argument
+    ///
+    /// EG: `action: (String) -> Void`
+    ///
+    /// - Parameter name: The name of the parameter
+    /// - Returns: A closure to be executed by the view
+    public func parameter<A>(name: String) -> (A) -> Void {
+        let parameter = closureParameter(
+            name: name,
+            signature: "(\(A.self)) -> Void"
+        )
+        
+        return { [unowned self] a in
+            parameter.wrappedValue.callCount += 1
+            self.log("\(name): (\(a))")
+        }
+    }
+    
+    /// A closure parameter with two arguments
+    ///
+    /// EG: `action: (String, Int) -> Void`
+    ///
+    /// - Parameter name: The name of the parameter
+    /// - Returns: A closure to be executed by the view
+    public func parameter<A, B>(name: String) -> (A, B) -> Void {
+        let parameter = closureParameter(
+            name: name,
+            signature: "(\(A.self), \(B.self)) -> Void"
+        )
+        
+        return { [unowned self] a, b in
+            parameter.wrappedValue.callCount += 1
+            self.log("\(name): (\(a), \(b))")
+        }
+    }
+    
+    /// A closure parameter with three arguments
+    ///
+    /// EG: `action: (String, Int, Bool) -> Void`
+    ///
+    /// - Parameter name: The name of the parameter
+    /// - Returns: A closure to be executed by the view
+    public func parameter<A, B, C>(name: String) -> (A, B, C) -> Void {
+        let parameter = closureParameter(
+            name: name,
+            signature: "(\(A.self), \(B.self), \(C.self)) -> Void"
+        )
+        
+        return { [unowned self] a, b, c in
+            parameter.wrappedValue.callCount += 1
+            self.log("\(name): (\(a), \(b), \(c))")
+        }
+    }
+    
+    /// A closure parameter with four arguments
+    ///
+    /// EG: `action: (String, Int, Bool, String) -> Void`
+    ///
+    /// - Parameter name: The name of the parameter
+    /// - Returns: A closure to be executed by the view
+    public func parameter<A, B, C, D>(name: String) -> (A, B, C, D) -> Void {
+        let parameter = closureParameter(
+            name: name,
+            signature: "(\(A.self), \(B.self), \(C.self), \(D.self)) -> Void"
+        )
+        
+        return { [unowned self] a, b, c, d in
+            parameter.wrappedValue.callCount += 1
+            self.log("\(name): (\(a), \(b), \(c), \(d))")
+        }
+    }
+    
+    /// Helper for creating a `ClosureParameter` binding without specifying types.
+    private func closureParameter(
+        name: String,
+        signature: String
+    ) -> Binding<ClosureParameter> {
+        parameter(
+            name: name,
+            defaultValue: .init(signature: signature)
+        )
+    }
+}

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -80,6 +80,7 @@ public struct Exhibition: View {
             .parameterView(BoolParameterView.self)
             .parameterView(IntParameterView.self)
             .parameterView(DateParameterView.self)
+            .parameterView(ClosureParameterView.self)
     }
     
     private var searchResults: [Exhibit] {

--- a/Sources/Exhibition/ParameterViews/ClosureParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/ClosureParameterView.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftUI
+
+/// A parameter representing a closure / function typed parameter.
+/// EG: `action: () -> Void`
+public struct ClosureParameter {
+    /// The signature of the closure, eg `"() -> Void"`
+    public let signature: String
+    
+    /// The number of times this closure has been called
+    public var callCount: Int = 0
+    
+    /// Initialize a `ClosureParameter`
+    /// - Parameter signature: The signature of the closure, such as `"() -> Void"`
+    public init(signature: String) {
+        self.signature = signature
+    }
+}
+
+struct ClosureParameterView: ParameterView {
+    let key: String
+    @Binding var value: ClosureParameter
+    
+    var body: some View {
+        HStack {
+            Text(key)
+            Spacer()
+            Text(value.signature)
+            Spacer()
+            Text(value.callCount.formatted())
+        }
+    }
+}


### PR DESCRIPTION
Resolves #22

Adds support for `context.parameter(...)` to return a closure for use in action-type scenarios.

The debug view shows the name and signature of the closure, along with a count of the times the closure has been executed.

On execution, the debug log will show the name along with the parameters passed into the execution.

`CustomButton` has been modified to pass a `Date` in its action closure as an example.

Currently without variadic generics, we must manually implement the various parameter counts. At the moment, I've included up to 4 parameters. If more are needed, the types are public such that a consumer can extend `Exhibit.Context` to add additional cases.

![Kapture 2022-02-23 at 10 33 55](https://user-images.githubusercontent.com/609274/155384790-019e71df-5981-47a1-8d6d-a6b6db19ab3e.gif)

