### PR TITLE
Fix double-presentation of debug view

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ exhibition
 
 - [ ] Layout
     - [x] iPhone
-    - [ ] iPad
+    - [x] iPad
     - [ ] macOS
     - [ ] watchOS
     - [ ] tvOS

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -5,7 +5,8 @@ public struct Exhibition: View {
     let exhibits: [Exhibit]
 
     @State var displayed: AnyHashable?
-    @State var debugViewPresented: Bool = false
+    @State var rootDebugViewPresented: Bool = false
+    @State var exhibitDebugViewPresented: Bool = false
     @State var searchText = ""
 
     // MARK: Accessibility
@@ -54,13 +55,13 @@ public struct Exhibition: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
-                        debugViewPresented = true
+                        rootDebugViewPresented = true
                     } label: {
                         Image(systemName: "gear")
                     }
                 }
             }
-            .sheet(isPresented: $debugViewPresented) {
+            .sheet(isPresented: $rootDebugViewPresented) {
                 DebugView(
                     context: .init(),
                     preferredColorScheme: $preferredColorScheme,
@@ -77,13 +78,13 @@ public struct Exhibition: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
-                        debugViewPresented = true
+                        exhibitDebugViewPresented = true
                     } label: {
                         Image(systemName: "gear")
                     }
                 }
             }
-            .sheet(isPresented: $debugViewPresented) {
+            .sheet(isPresented: $exhibitDebugViewPresented) {
                 DebugView(
                     context: exhibit.context,
                     preferredColorScheme: $preferredColorScheme,


### PR DESCRIPTION
Fixes incorrect presentation of debug view without context on iPad.
Resolves numerous warnings in Xcode console.

![Kapture 2022-02-23 at 12 18 30](https://user-images.githubusercontent.com/609274/155401328-ee57e721-c840-4a74-b233-4b9480b8b894.gif)

