### PR TITLE
Add custom layout builder to Exhibit

### DIFF
--- a/Example/CustomButton.swift
+++ b/Example/CustomButton.swift
@@ -18,7 +18,6 @@ struct CustomButton_Previews: ExhibitProvider, PreviewProvider {
             title: context.parameter(name: "title", defaultValue: "Title"),
             action: context.parameter(name: "action")
         )
-            .previewLayout(.sizeThatFits)
     }
 }
 

--- a/Example/CustomToggle.swift
+++ b/Example/CustomToggle.swift
@@ -17,5 +17,8 @@ struct CustomToggle_Previews: ExhibitProvider, PreviewProvider {
             isOn: context.parameter(name: "isOn")
         )
             .previewLayout(.sizeThatFits)
+    } layout: { exhibit in
+        exhibit
+            .padding()
     }
 }

--- a/Example/CustomToggle.swift
+++ b/Example/CustomToggle.swift
@@ -16,7 +16,6 @@ struct CustomToggle_Previews: ExhibitProvider, PreviewProvider {
             title: context.parameter(name: "title", defaultValue: "Title"),
             isOn: context.parameter(name: "isOn")
         )
-            .previewLayout(.sizeThatFits)
     } layout: { exhibit in
         exhibit
             .padding()

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ exhibition
 - [x] Exhibit
     - [x] Push
     - [ ] Present
-    - [ ] Layout rules (#4)
+    - [x] Layout rules (#4)
     - [x] Parameters (#3)
     
     - [ ] Code samples (copy-able snippets)

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -5,13 +5,20 @@ public struct Exhibit: View {
     let name: String
     let section: String
     let view: (Context) -> AnyView
-    
+    let layout: (Self) -> AnyView
+
     @ObservedObject var context = Context()
     
-    public init<T: View>(name: String, section: String = "", @ViewBuilder _ builder: @escaping (Context) -> T) {
+    public init<T: View, S: View>(
+        name: String,
+        section: String = "",
+        @ViewBuilder builder: @escaping (Context) -> T,
+        @ViewBuilder layout: @escaping (Self) -> S
+    ) {
         self.name = name
         self.section = section
         view = { context in AnyView(builder(context)) }
+        self.layout = { exhibit in AnyView(layout(exhibit)) }
     }
     
     public var body: some View {
@@ -26,3 +33,16 @@ extension Exhibit: Identifiable {
     }
 }
 
+extension Exhibit {
+    public init<T: View>(
+        name: String,
+        section: String = "",
+        @ViewBuilder builder: @escaping (Context) -> T
+    ) {
+        self.init(
+            name: name,
+            section: section,
+            builder: builder
+        ) { AnyView($0) }
+    }
+}

--- a/Sources/Exhibition/ExhibitProvider.swift
+++ b/Sources/Exhibition/ExhibitProvider.swift
@@ -7,5 +7,6 @@ public protocol ExhibitProvider {
 public extension ExhibitProvider {
     static var previews: some View {
         exhibit
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -73,7 +73,7 @@ public struct Exhibition: View {
     }
     
     private func debuggable(_ exhibit: Exhibit) -> some View {
-        exhibit
+        exhibit.layout(exhibit)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {


### PR DESCRIPTION
Resolves #4 

Allows for customization of the view that is displayed in the exhibition. For example, adding padding, inserting in a list, positioning, etc.

This layout builder does not affect SwiftUI previews.

Also uses `sizeThatFits` as default preview layout. Consumers can implement their own `static var previews` if they wish to change this

![Screen Shot 2022-02-23 at 12 22 59](https://user-images.githubusercontent.com/609274/155401962-efff925d-549e-4f88-95cb-4a28f025065d.png)

