### PR TITLE
Exploration into custom presentation via Layout

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		D4B3610927B18839001F5E20 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B3610827B18839001F5E20 /* CustomButton.swift */; };
 		D4B3611127B1896A001F5E20 /* Exhibition in Frameworks */ = {isa = PBXBuildFile; productRef = D4B3611027B1896A001F5E20 /* Exhibition */; };
 		D4C4975327B451950061244C /* CustomToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C4975227B451950061244C /* CustomToggle.swift */; };
+		D4E48B7627C8022A00A8D8F0 /* CustomPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E48B7527C8022A00A8D8F0 /* CustomPopover.swift */; };
 		D4E576A327B5988A00A97BB7 /* Exhibition.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E576A227B5988A00A97BB7 /* Exhibition.generated.swift */; };
 /* End PBXBuildFile section */
 
@@ -28,6 +29,7 @@
 		D4B360FF27B187EE001F5E20 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		D4B3610827B18839001F5E20 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		D4C4975227B451950061244C /* CustomToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToggle.swift; sourceTree = "<group>"; };
+		D4E48B7527C8022A00A8D8F0 /* CustomPopover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomPopover.swift; sourceTree = "<group>"; };
 		D4E576A227B5988A00A97BB7 /* Exhibition.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exhibition.generated.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -68,6 +70,7 @@
 				D4B3610827B18839001F5E20 /* CustomButton.swift */,
 				D4C4975227B451950061244C /* CustomToggle.swift */,
 				D42B337A27BD7E710071C18E /* CustomDatePicker.swift */,
+				D4E48B7527C8022A00A8D8F0 /* CustomPopover.swift */,
 				D4B360F827B187EC001F5E20 /* ExampleApp.swift */,
 				D4E576A227B5988A00A97BB7 /* Exhibition.generated.swift */,
 				D4B360FC27B187EE001F5E20 /* Assets.xcassets */,
@@ -195,6 +198,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D4E48B7627C8022A00A8D8F0 /* CustomPopover.swift in Sources */,
 				D4E576A327B5988A00A97BB7 /* Exhibition.generated.swift in Sources */,
 				D4B360FB27B187EC001F5E20 /* ContentView.swift in Sources */,
 				D42B337B27BD7E710071C18E /* CustomDatePicker.swift in Sources */,

--- a/Example/CustomPopover.swift
+++ b/Example/CustomPopover.swift
@@ -1,0 +1,40 @@
+import Exhibition
+import SwiftUI
+
+struct CustomPopover: View {
+    let contents: String
+    
+    var body: some View {
+        Text(contents)
+    }
+}
+
+struct CustomPopover_Previews: PreviewProvider, ExhibitProvider {
+    static var exhibit: Exhibit = Exhibit(
+        name: "CustomPopover",
+        layout: Layout.init(exhibit:)
+    ) { context in
+        CustomPopover(
+            contents: context.parameter(name: "contents", defaultValue: "Contents")
+        )
+    }
+    
+    struct Layout: View {
+        let exhibit: Exhibit
+        
+        init(exhibit: Exhibit) {
+            self.exhibit = exhibit
+        }
+        
+        @State var popover: Bool = false
+        
+        var body: some View {
+            Button("Open Popover") {
+                popover = true
+            }
+            .popover(isPresented: $popover) {
+                exhibit
+            }
+        }
+    }
+}

--- a/Example/CustomToggle.swift
+++ b/Example/CustomToggle.swift
@@ -11,13 +11,13 @@ struct CustomToggle: View {
 }
 
 struct CustomToggle_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit = Exhibit(name: "CustomToggle") { context in
+    static var exhibit = Exhibit(name: "CustomToggle") { exhibit in
+        exhibit
+            .padding()
+    } builder: { context in
         CustomToggle(
             title: context.parameter(name: "title", defaultValue: "Title"),
             isOn: context.parameter(name: "isOn")
         )
-    } layout: { exhibit in
-        exhibit
-            .padding()
     }
 }

--- a/Example/Exhibition.generated.swift
+++ b/Example/Exhibition.generated.swift
@@ -7,6 +7,7 @@ public let exhibition = Exhibition(
     exhibits: [
         CustomButton_Previews.exhibit,
         CustomDatePicker_Previews.exhibit,
+        CustomPopover_Previews.exhibit,
         CustomToggle_Previews.exhibit,
     ]
 )

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -19,6 +19,8 @@ public struct Exhibit: View {
         self.section = section
         view = { context in AnyView(builder(context)) }
         self.layout = { exhibit in AnyView(layout(exhibit)) }
+        
+        _ = builder(context) // Ensure context is filled
     }
     
     public var body: some View {

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -12,8 +12,8 @@ public struct Exhibit: View {
     public init<T: View, S: View>(
         name: String,
         section: String = "",
-        @ViewBuilder builder: @escaping (Context) -> T,
-        @ViewBuilder layout: @escaping (Self) -> S
+        @ViewBuilder layout: @escaping (Self) -> S,
+        @ViewBuilder builder: @escaping (Context) -> T
     ) {
         self.name = name
         self.section = section
@@ -42,7 +42,8 @@ extension Exhibit {
         self.init(
             name: name,
             section: section,
+            layout: { AnyView($0) },
             builder: builder
-        ) { AnyView($0) }
+        )
     }
 }


### PR DESCRIPTION
Relates to #32

Using the `layout` system for presentation has exposed a large issue with the layout system design, and perhaps with the underlying exhibit Context -> Debug menu relationship.

The layout closure allows for insertion of additional views before conditionally displaying the exhibit.

This bypasses the path that fills the parameter list, causing the context to not appear in the debug menu until the popover has been displayed once.

Resolving this could involve refactoring the Context passing mechanism, or adjusting the layout system to work with the current mechanism. Further exploration is needed.