### PR TITLE
Support package compilation on watchOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,10 @@ jobs:
         - sdk: "iphonesimulator"
           destination: "platform=iOS Simulator,OS=15.2,name=iPhone 12 Pro Max"
           
+        # Latest watchOS
+        - sdk: "watchsimulator"
+          destination: "OS=8.3,Apple Watch Series 7 - 45mm"
+          
         # Latest macOS (disabled due to lack of macOS UI support)
         #- sdk: "macosx12.1"
         #destination: "platform=macOS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           
         # Latest watchOS
         - sdk: "watchsimulator"
-          destination: "OS=8.3,Apple Watch Series 7 - 45mm"
+          destination: "OS=8.3,name=Apple Watch Series 7 - 45mm"
           
         # Latest macOS (disabled due to lack of macOS UI support)
         #- sdk: "macosx12.1"

--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -37,14 +37,20 @@ struct DebugView: View {
                 if context.log.isEmpty == false {
                     Section("Log") {
                         Text(context.log.joined(separator: "\n"))
-                            .textSelection(.enabled)
+                            .modify {
+                                #if os(iOS)
+                                    $0.textSelection(.enabled)
+                                #else
+                                    $0
+                                #endif
+                            }
                     }
                 }
             }
             .navigationTitle("Debug")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem {
                     Button("Done") {
                         dismiss()
                     }

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -53,7 +53,7 @@ public struct Exhibition: View {
             .navigationTitle("Exhibit")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem {
                     Button {
                         rootDebugViewPresented = true
                     } label: {
@@ -76,7 +76,7 @@ public struct Exhibition: View {
     private func debuggable(_ exhibit: Exhibit) -> some View {
         exhibit.layout(exhibit)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem {
                     Button {
                         exhibitDebugViewPresented = true
                     } label: {

--- a/Sources/Exhibition/ParameterViews/DateParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/DateParameterView.swift
@@ -1,5 +1,24 @@
 import SwiftUI
 
+#if os(watchOS)
+
+struct DateParameterView: ParameterView {
+    let key: String
+    @Binding var value: Date
+
+    var body: some View {
+        HStack {
+            Text(key)
+            
+            Spacer()
+            
+            Text(value.formatted())
+        }
+    }
+}
+
+#else
+
 extension DatePicker: ParameterView where Label == Text {
     public init(key: String, value: Binding<Date>) {
         self.init(key, selection: value)
@@ -7,3 +26,5 @@ extension DatePicker: ParameterView where Label == Text {
 }
 
 typealias DateParameterView = DatePicker
+
+#endif

--- a/Sources/Exhibition/ParameterViews/IntParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/IntParameterView.swift
@@ -1,5 +1,25 @@
 import SwiftUI
 
+#if os(watchOS)
+
+extension Slider: ParameterView where ValueLabel == EmptyView, Label == Text {
+    public init(key: String, value: Binding<Int>) {
+        self.init(
+            value: Binding(
+                get: { Float(value.wrappedValue) },
+                set: { value.wrappedValue = Int($0) }
+            ),
+            label: {
+                Text(key)
+            }
+        )
+    }
+}
+
+typealias IntParameterView = Slider
+
+#else
+
 extension Stepper: ParameterView where Label == Text {
     public init(key: String, value: Binding<Int>) {
         self.init(key, value: value)
@@ -7,3 +27,5 @@ extension Stepper: ParameterView where Label == Text {
 }
 
 typealias IntParameterView = Stepper
+
+#endif

--- a/Sources/Exhibition/Utilities/View+Modify.swift
+++ b/Sources/Exhibition/Utilities/View+Modify.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Helpers for conditionally applying modifiers
+extension View {
+    
+    /// Modify the current view with some given block. Useful for applying compiler conditional modifiers.
+    ///
+    /// Example:
+    ///
+    ///     Rectangle().modify {
+    ///         #if os(iOS)
+    ///             $0.fill(Color.red)
+    ///         #else
+    ///            $0.fill(Color.blue)
+    ///         #endif
+    ///     }
+    ///
+    /// - Returns: A modified view
+    @ViewBuilder public func modify<Output: View>(
+        _ block: (Self) -> Output
+    ) -> some View {
+        block(self)
+    }
+}


### PR DESCRIPTION
Resolves #36 

Adjusts UI code to support watchOS, removing unsupported features and adding conditionals when necessary.

Note: WatchOS UI is completely untested and unverified, this only makes the framework compile.