### PR TITLE
Allow customization of Exhibition display

### DIFF
--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        exhibition
+        Exhibition()
     }
 }
 

--- a/Example/Exhibition.generated.swift
+++ b/Example/Exhibition.generated.swift
@@ -3,16 +3,22 @@
 import Exhibition
 import SwiftUI
 
-public let exhibition = Exhibition(
-    exhibits: [
-        CustomButton_Previews.exhibit,
-        CustomDatePicker_Previews.exhibit,
-        CustomToggle_Previews.exhibit,
-    ]
-)
+public struct Exhibition: View {
+    public var body: some View {
+        NavigationView {
+            ExhibitListView(
+                exhibits: [
+                    CustomButton_Previews.exhibit,
+                    CustomDatePicker_Previews.exhibit,
+                    CustomToggle_Previews.exhibit,
+                ]
+            )
+        }
+    }
+}
 
 struct Exhibition_Previews: PreviewProvider {
     static var previews: some View {
-        exhibition
+        Exhibition()
     }
 }

--- a/Exhibition.swifttemplate
+++ b/Exhibition.swifttemplate
@@ -2,15 +2,21 @@
 import Exhibition
 import SwiftUI
 
-public let exhibition = Exhibition(
-    exhibits: [<% for type in types.types where type.inheritedTypes.contains("ExhibitProvider") { %>
-        <%= type.name %>.exhibit,<% } %>
-    ]
-)
+public struct Exhibition: View {
+    public var body: some View {
+        NavigationView {
+            ExhibitListView(
+                exhibits: [<% for type in types.types where type.inheritedTypes.contains("ExhibitProvider") { %>
+                    <%= type.name %>.exhibit,<% } %>
+                ]
+            )
+        }
+    }
+}
 
 struct Exhibition_Previews: PreviewProvider {
     static var previews: some View {
-        exhibition
+        Exhibition()
     }
 }
 // sourcery:end

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ struct DoublingStringParameterView: ParameterView {
     }
 }
 
-exhibition
+Exhibition()
     .parameterView(DoublingStringParameterView.self)
 ```
 

--- a/Sources/Exhibition/Utilities/View+Modify.swift
+++ b/Sources/Exhibition/Utilities/View+Modify.swift
@@ -21,4 +21,44 @@ extension View {
     ) -> some View {
         block(self)
     }
+    
+    /// Conditionally apply modifiers to a given view
+    ///
+    /// See `ifLet` for version that takes an optional.
+    ///
+    /// - Parameters:
+    ///   - condition: Condition returning true/false for execution of the following blocks
+    ///   - then: If condition is true, apply modifiers here.
+    ///   - else: If condition is false, apply modifiers here.
+    /// - Returns: Self with modifiers applied accordingly.
+    @ViewBuilder public func `if`<Then: View, Else: View>(
+        _ condition: @autoclosure () -> Bool,
+        @ViewBuilder then: (Self) -> Then,
+        @ViewBuilder else: (Self) -> Else
+    ) -> some View {
+        if condition() {
+            then(self)
+        } else {
+            `else`(self)
+        }
+    }
+
+    /// Conditionally apply modifiers to a given view
+    ///
+    /// See `ifLet` for version that takes an optional.
+    ///
+    /// - Parameters:
+    ///   - condition: Condition returning true/false for execution of the following blocks
+    ///   - then: If condition is true, apply modifiers here.
+    /// - Returns: Self with modifiers applied, or unchanged self if condition was false
+    @ViewBuilder public func `if`<Then: View>(
+        _ condition: @autoclosure () -> Bool,
+        @ViewBuilder then: (Self) -> Then
+    ) -> some View {
+        if condition() {
+            then(self)
+        } else {
+            self
+        }
+    }
 }


### PR DESCRIPTION
Moves the `NavigationView` out into the swift template.
This allows for customization of the template, for example, to push onto an exiting navigation stack instead, or to modify toolbar items.

Also adds a close button if the exhibit list is presented.

Closes #38 