### PR TITLE
Support modifying parameters in multiple previews

### DIFF
--- a/Example/CustomButton.swift
+++ b/Example/CustomButton.swift
@@ -19,5 +19,13 @@ struct CustomButton_Previews: ExhibitProvider, PreviewProvider {
             action: context.parameter(name: "action")
         )
     }
+    
+    static var previews: some View {
+        exhibit.preview()
+            .previewLayout(.sizeThatFits)
+        
+        exhibit.preview(parameters: ["title": "Other"])
+            .previewLayout(.sizeThatFits)
+    }
 }
 

--- a/Example/CustomToggle.swift
+++ b/Example/CustomToggle.swift
@@ -16,8 +16,9 @@ struct CustomToggle_Previews: ExhibitProvider, PreviewProvider {
             title: context.parameter(name: "title", defaultValue: "Title"),
             isOn: context.parameter(name: "isOn")
         )
-    } layout: { exhibit in
-        exhibit
-            .padding()
+    }
+    
+    static func exhibitLayout(_ content: CustomToggle) -> some View {
+        content.padding()
     }
 }

--- a/Example/Exhibition.generated.swift
+++ b/Example/Exhibition.generated.swift
@@ -5,9 +5,9 @@ import SwiftUI
 
 public let exhibition = Exhibition(
     exhibits: [
-        CustomButton_Previews.exhibit,
-        CustomDatePicker_Previews.exhibit,
-        CustomToggle_Previews.exhibit,
+        CustomButton_Previews.anyExhibit,
+        CustomDatePicker_Previews.anyExhibit,
+        CustomToggle_Previews.anyExhibit,
     ]
 )
 

--- a/Exhibition.swifttemplate
+++ b/Exhibition.swifttemplate
@@ -4,7 +4,7 @@ import SwiftUI
 
 public let exhibition = Exhibition(
     exhibits: [<% for type in types.types where type.inheritedTypes.contains("ExhibitProvider") { %>
-        <%= type.name %>.exhibit,<% } %>
+        <%= type.name %>.anyExhibit,<% } %>
     ]
 )
 

--- a/Sources/Exhibition/Context.swift
+++ b/Sources/Exhibition/Context.swift
@@ -1,47 +1,49 @@
 import SwiftUI
 
-extension Exhibit {
-    public class Context: ObservableObject {
-        @Published var parameters: [String: Any] = [:]
-        @Published var log: [String] = []
+public class Context: ObservableObject {
+    @Published var parameters: [String: Any]
+    @Published var log: [String] = []
+    
+    init(parameters: [String: Any] = [:]) {
+        self.parameters = parameters
+    }
+    
+    public func parameter<T>(name: String, defaultValue: T) -> T {
+        guard let binding = parameters[name] else {
+            parameters[name] = defaultValue
+            return defaultValue
+        }
         
-        public func parameter<T>(name: String, defaultValue: T) -> T {
-            guard let binding = parameters[name] else {
-                parameters[name] = defaultValue
-                return defaultValue
+        return binding as! T
+    }
+    
+    public func parameter<T>(name: String) -> T where T: Defaultable {
+        parameter(name: name, defaultValue: T.defaultValue)
+    }
+    
+    public func parameter<T>(name: String, defaultValue: T) -> Binding<T> {
+        return Binding(
+            get: { [unowned self] in
+                self.parameter(name: name, defaultValue: defaultValue)
+            },
+            set: { [unowned self] newValue in
+                parameters[name] = newValue
             }
-            
-            return binding as! T
-        }
-        
-        public func parameter<T>(name: String) -> T where T: Defaultable {
-            parameter(name: name, defaultValue: T.defaultValue)
-        }
-        
-        public func parameter<T>(name: String, defaultValue: T) -> Binding<T> {
-            return Binding(
-                get: { [unowned self] in
-                    self.parameter(name: name, defaultValue: defaultValue)
-                },
-                set: { [unowned self] newValue in
-                    parameters[name] = newValue
-                }
-            )
-        }
-        
-        public func parameter<T>(name: String) -> Binding<T> where T: Defaultable {
-            parameter(name: name, defaultValue: T.defaultValue)
-        }
-        
-        public func log(_ text: String) {
-            log.append(text)
-        }
+        )
+    }
+    
+    public func parameter<T>(name: String) -> Binding<T> where T: Defaultable {
+        parameter(name: name, defaultValue: T.defaultValue)
+    }
+    
+    public func log(_ text: String) {
+        log.append(text)
     }
 }
 
 // MARK: - Closure Parameters
 
-extension Exhibit.Context {
+extension Context {
     /// A closure parameter with no arguments
     ///
     /// EG: `action: () -> Void`

--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// A presented view used to modify accessibility and exhibit parameters.
 struct DebugView: View {
-    @ObservedObject var context: Exhibit.Context
+    @ObservedObject var context: Context
     
     @Binding var preferredColorScheme: ColorScheme
     @Binding var layoutDirection: LayoutDirection

--- a/Sources/Exhibition/ExhibitProvider.swift
+++ b/Sources/Exhibition/ExhibitProvider.swift
@@ -1,12 +1,28 @@
 import SwiftUI
 
 public protocol ExhibitProvider {
-    static var exhibit: Exhibit { get }
+    associatedtype Content: View
+    associatedtype Layout: View
+    
+    static var exhibit: Exhibit<Content> { get }
+    
+    static func exhibitLayout(_ content: Content) -> Layout
 }
 
 public extension ExhibitProvider {
     static var previews: some View {
         exhibit
+            .preview()
             .previewLayout(.sizeThatFits)
+    }
+    
+    static var anyExhibit: AnyExhibit {
+        AnyExhibit(exhibit, layout: exhibitLayout)
+    }
+}
+
+public extension ExhibitProvider where Content == Layout {
+    static func exhibitLayout(_ content: Content) -> Layout {
+        content
     }
 }

--- a/Sources/Exhibition/Exhibition.swift
+++ b/Sources/Exhibition/Exhibition.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 public struct Exhibition: View {
 
-    let exhibits: [Exhibit]
+    let exhibits: [AnyExhibit]
 
     @State var displayed: AnyHashable?
     @State var rootDebugViewPresented: Bool = false
@@ -13,7 +13,7 @@ public struct Exhibition: View {
     @State var preferredColorScheme: ColorScheme = .light
     @State var layoutDirection: LayoutDirection = .leftToRight
     
-    private var sections: [String: [Exhibit]] {
+    private var sections: [String: [AnyExhibit]] {
         Dictionary(grouping: searchResults, by: \.section)
     }
 
@@ -30,7 +30,7 @@ public struct Exhibition: View {
         )
     }
 
-    public init(exhibits: [Exhibit]) {
+    public init(exhibits: [AnyExhibit]) {
         self.exhibits = exhibits
     }
 
@@ -80,8 +80,9 @@ public struct Exhibition: View {
         .environment(\.layoutDirection, layoutDirection)
     }
     
-    private func debuggable(_ exhibit: Exhibit) -> some View {
-        exhibit.layout(exhibit)
+    private func debuggable(_ exhibit: AnyExhibit) -> some View {
+        let context = Context()
+        return AnyExhibitView(exhibit: exhibit, context: context)
             .toolbar {
                 ToolbarItem {
                     Button {
@@ -93,7 +94,7 @@ public struct Exhibition: View {
             }
             .sheet(isPresented: $exhibitDebugViewPresented) {
                 DebugView(
-                    context: exhibit.context,
+                    context: context,
                     preferredColorScheme: $preferredColorScheme,
                     layoutDirection: $layoutDirection
                 )
@@ -105,7 +106,7 @@ public struct Exhibition: View {
             .parameterView(ClosureParameterView.self)
     }
     
-    private var searchResults: [Exhibit] {
+    private var searchResults: [AnyExhibit] {
         if searchText.isEmpty {
             return exhibits
         } else {
@@ -118,15 +119,23 @@ public struct Exhibition: View {
 }
 
 struct Exhibition_Previews: PreviewProvider {
+    struct First: ExhibitProvider {
+        static let exhibit = Exhibit(name: "Text", section: "Section 1") { context in
+            Text(context.parameter(name: "Content", defaultValue: "Text"))
+        }
+    }
+    
+    struct Second: ExhibitProvider {
+        static let exhibit = Exhibit(name: "Text", section: "Section 1") { context in
+            Text(context.parameter(name: "Content", defaultValue: "Text"))
+        }
+    }
+    
     static var previews: some View {
         Exhibition(
             exhibits: [
-                .init(name: "Text", section: "Section 1") { context in
-                    Text(context.parameter(name: "Content", defaultValue: "Text"))
-                },
-                .init(name: "Text2", section: "Section 2") { context in
-                    Text(context.parameter(name: "Content", defaultValue: "Text"))
-                }
+                First.anyExhibit,
+                Second.anyExhibit,
             ]
         )
     }

--- a/Sources/Exhibition/ParameterView.swift
+++ b/Sources/Exhibition/ParameterView.swift
@@ -25,7 +25,7 @@ extension View {
 // MARK: - Internal
 
 /// Type erased parameter view for storage in an array.
-typealias AnyParameterView = (String, Any, Exhibit.Context) -> AnyView?
+typealias AnyParameterView = (String, Any, Context) -> AnyView?
 func erase<P: ParameterView>(_ parameterView: P.Type) -> AnyParameterView {
     return { name, value, parameters in
         guard let value = value as? P.Value else {


### PR DESCRIPTION
Resolves #14

This allows for consumers to override parameters in previews by using `Exhibit.preview(parameters: [String: Any]) -> some View`

This allows for multiple previews to be had for easing development.

In order to support the passing of parameters in this way, some refactoring was required:

`Exhibit` is now a strict model, not a view itself, allowing it to be generic and more easily understood.

`AnyExhibit` is added which is a type-erased version for use in arrays, and then `AnyExhibitView` displays the actual exhibit with support for context observing.

For some reason, a compiler error unfortunately occurs in the preview definition if `layout` is left as a closure on `Exhibit`. The only solution I could find which left types intact is to move the layout override to a separate function in the `Exhibit` protocol.