### PR TITLE
Add public init to Sourcery template fix inaccessible initializer warnings

### DIFF
--- a/Exhibition.swifttemplate
+++ b/Exhibition.swifttemplate
@@ -3,6 +3,8 @@ import Exhibition
 import SwiftUI
 
 public struct Exhibition: View {
+    public init() {}
+    
     public var body: some View {
         NavigationView {
             ExhibitListView(


### PR DESCRIPTION
fixes #41 

Add public init to fix inaccessible initializer warnings. 

Previously, when consuming this generated struct from outside of the module you would get a warning of an inaccessible public initializer. 