### PR TITLE
Remove conditional close button

### DIFF
--- a/Sources/Exhibition/ExhibitListView.swift
+++ b/Sources/Exhibition/ExhibitListView.swift
@@ -13,8 +13,6 @@ public struct ExhibitListView: View {
     @State var preferredColorScheme: ColorScheme = .light
     @State var layoutDirection: LayoutDirection = .leftToRight
     
-    @Environment(\.presentationMode) var presentationMode
-    
     private var sections: [String: [Exhibit]] {
         Dictionary(grouping: searchResults, by: \.section)
     }
@@ -67,17 +65,6 @@ public struct ExhibitListView: View {
                 } label: {
                     Image(systemName: "gear")
                 }
-            }
-        }
-        .if(presentationMode.wrappedValue.isPresented) {
-            $0.toolbar {
-                #if !os(macOS) && !os(watchOS)
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Close") {
-                        presentationMode.wrappedValue.dismiss()
-                    }
-                }
-                #endif
             }
         }
         .sheet(isPresented: $rootDebugViewPresented) {


### PR DESCRIPTION
Resolves #42

This caused an undesirable situation where if the containing controller was presented it still showed the close button.

Instead, if the consumer wants a close button, they can add it in the sourcery template.