### PR TITLE
Debuggable Enum parameters

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D40AF62927D682B7006A5763 /* CustomSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40AF62827D682B7006A5763 /* CustomSegmentedControl.swift */; };
+		D40AF62A27D682B7006A5763 /* CustomSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40AF62827D682B7006A5763 /* CustomSegmentedControl.swift */; };
 		D4E48B5827C702A800A8D8F0 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E48B4927C702A600A8D8F0 /* ExampleApp.swift */; };
 		D4E48B5927C702A800A8D8F0 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E48B4927C702A600A8D8F0 /* ExampleApp.swift */; };
 		D4E48B5A27C702A800A8D8F0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E48B4A27C702A600A8D8F0 /* ContentView.swift */; };
@@ -26,6 +28,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		D40AF62827D682B7006A5763 /* CustomSegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSegmentedControl.swift; sourceTree = "<group>"; };
 		D42B337A27BD7E710071C18E /* CustomDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDatePicker.swift; sourceTree = "<group>"; };
 		D45C4ED327B1CE5000BA8515 /*  */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = ""; sourceTree = "<group>"; };
 		D4B3610827B18839001F5E20 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
@@ -86,6 +89,7 @@
 				D4B3610827B18839001F5E20 /* CustomButton.swift */,
 				D4C4975227B451950061244C /* CustomToggle.swift */,
 				D42B337A27BD7E710071C18E /* CustomDatePicker.swift */,
+				D40AF62827D682B7006A5763 /* CustomSegmentedControl.swift */,
 				D4E48B4927C702A600A8D8F0 /* ExampleApp.swift */,
 				D4E48B4A27C702A600A8D8F0 /* ContentView.swift */,
 				D4E48B4B27C702A800A8D8F0 /* Assets.xcassets */,
@@ -253,6 +257,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D40AF62927D682B7006A5763 /* CustomSegmentedControl.swift in Sources */,
 				D4E48B6927C7039400A8D8F0 /* CustomButton.swift in Sources */,
 				D4E48B5A27C702A800A8D8F0 /* ContentView.swift in Sources */,
 				D4E48B6B27C7039400A8D8F0 /* CustomDatePicker.swift in Sources */,
@@ -266,6 +271,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D40AF62A27D682B7006A5763 /* CustomSegmentedControl.swift in Sources */,
 				D4E48B6C27C7039400A8D8F0 /* CustomButton.swift in Sources */,
 				D4E48B5B27C702A800A8D8F0 /* ContentView.swift in Sources */,
 				D4E48B6E27C7039400A8D8F0 /* CustomDatePicker.swift in Sources */,

--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
+import Exhibition
 
 struct ContentView: View {
     var body: some View {
         Exhibition()
+            .parameterView(EnumParameterView<CustomSegmentedControl.Option>.self)
     }
 }
 

--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -1,10 +1,8 @@
 import SwiftUI
-import Exhibition
 
 struct ContentView: View {
     var body: some View {
         Exhibition()
-            .parameterView(EnumParameterView<CustomSegmentedControl.Option>.self)
     }
 }
 

--- a/Example/CustomSegmentedControl.swift
+++ b/Example/CustomSegmentedControl.swift
@@ -1,0 +1,38 @@
+import Exhibition
+import SwiftUI
+
+struct CustomSegmentedControl: View {
+    let title: String
+    @Binding var selection: Option
+    
+    var body: some View {
+        Picker(title, selection: $selection) {
+            ForEach(Option.allCases, id: \.rawValue) { option in
+                Text(option.rawValue).tag(option)
+            }
+        }
+        .pickerStyle(SegmentedPickerStyle())
+    }
+    
+    enum Option: String, CaseIterable, CustomDebugStringConvertible {
+        case first = "first"
+        case second = "second"
+        case third = "third"
+        
+        var debugDescription: String {
+            rawValue
+        }
+    }
+}
+
+struct CustomSegmentedControl_Previews: ExhibitProvider, PreviewProvider {
+    static var exhibit: Exhibit = Exhibit(
+        name: "CustomSegmentedControl",
+        section: "Pickers"
+    ) { context in
+        CustomSegmentedControl(
+            title: context.parameter(name: "title", defaultValue: "Title"),
+            selection: context.parameter(name: "selection", defaultValue: .first)
+        )
+    }
+}

--- a/Example/Exhibition.generated.swift
+++ b/Example/Exhibition.generated.swift
@@ -4,6 +4,8 @@ import Exhibition
 import SwiftUI
 
 public struct Exhibition: View {
+    public init() {}
+    
     public var body: some View {
         NavigationView {
             ExhibitListView(

--- a/Example/Exhibition.generated.swift
+++ b/Example/Exhibition.generated.swift
@@ -10,6 +10,7 @@ public struct Exhibition: View {
                 exhibits: [
                     CustomButton_Previews.anyExhibit,
                     CustomDatePicker_Previews.anyExhibit,
+                    CustomSegmentedControl_Previews.anyExhibit,
                     CustomToggle_Previews.anyExhibit,
                 ]
             )

--- a/Sources/Exhibition/ExhibitListView.swift
+++ b/Sources/Exhibition/ExhibitListView.swift
@@ -102,6 +102,7 @@ public struct ExhibitListView: View {
             .parameterView(IntParameterView.self)
             .parameterView(DateParameterView.self)
             .parameterView(ClosureParameterView.self)
+            .parameterView(EnumParameterView.self)
     }
     
     private var searchResults: [AnyExhibit] {

--- a/Sources/Exhibition/ParameterViews/EnumParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/EnumParameterView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+public struct EnumParameterView<Value: CaseIterable & CustomDebugStringConvertible & Hashable>: ParameterView {
+    let key: String
+    @Binding var value: Value
+    
+    public init(key: String, value: Binding<Value>) {
+        self.key = key
+        _value = value
+    }
+    
+    public var body: some View {
+        Picker(key, selection: $value) {
+            ForEach(Array(Value.allCases), id: \.debugDescription) { option in
+                Text(option.debugDescription).tag(option)
+            }
+        }
+    }
+}

--- a/Sources/Exhibition/ParameterViews/EnumParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/EnumParameterView.swift
@@ -1,26 +1,15 @@
 import SwiftUI
 
-public struct EnumParameter {
-    public typealias EnumType = CaseIterable & CustomDebugStringConvertible & Hashable
+public extension Context {
+    /// Helper enum to avoid repetition of protocols below
+    typealias EnumType = CaseIterable & CustomDebugStringConvertible & Hashable
     
-    var current: AnyHashable
-    let cases: [String: AnyHashable]
-    
-    init<E: EnumType>(value: E) {
-        self.current = value
-        self.cases = Dictionary(uniqueKeysWithValues: E.allCases.map {
-            ($0.debugDescription, $0)
-        })
-    }
-    
-    func value<E>() -> E? {
-        return current as? E
-    }
-}
-
-
-public extension Exhibit.Context {
-    func parameter<E: EnumParameter.EnumType>(name: String, defaultValue: E) -> E {
+    /// Create a constant parameter for a selectable Enum
+    /// - Parameters:
+    ///   - name: The debug description name for the parameter.
+    ///   - defaultValue: The initial case for the enum.
+    /// - Returns: The currently selected case of the enum
+    func parameter<E: EnumType>(name: String, defaultValue: E) -> E {
         let parameter: EnumParameter = parameter(
             name: name,
             defaultValue: EnumParameter(value: defaultValue)
@@ -29,7 +18,12 @@ public extension Exhibit.Context {
         return parameter.current as! E
     }
     
-    func parameter<E: EnumParameter.EnumType>(name: String, defaultValue: E) -> Binding<E> {
+    /// Create a binding parameter for a selectable enum
+    /// - Parameters:
+    ///   - name: The debug description name for the parameter.
+    ///   - defaultValue: The initial case for the enum.
+    /// - Returns: A binding for the currently selected case of the enum
+    func parameter<E: EnumType>(name: String, defaultValue: E) -> Binding<E> {
         let parameter: Binding<EnumParameter> = parameter(
             name: name,
             defaultValue: EnumParameter(value: defaultValue)
@@ -42,14 +36,27 @@ public extension Exhibit.Context {
     }
 }
 
-public struct EnumParameterView: ParameterView {
+/// A parameter representing a selectable Enum
+struct EnumParameter {
+    var current: AnyHashable
+    let cases: [String: AnyHashable]
+    
+    init<E: Context.EnumType>(value: E) {
+        self.current = value
+        self.cases = Dictionary(uniqueKeysWithValues: E.allCases.map {
+            ($0.debugDescription, $0)
+        })
+    }
+    
+    func value<E>() -> E? {
+        return current as? E
+    }
+}
+
+/// Debug parameter row for `EnumParameter`
+struct EnumParameterView: ParameterView {
     let key: String
     @Binding var value: EnumParameter
-    
-    public init(key: String, value: Binding<EnumParameter>) {
-        self.key = key
-        _value = value
-    }
     
     public var body: some View {
         Picker(key, selection: $value.current) {

--- a/Sources/Exhibition/ParameterViews/EnumParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/EnumParameterView.swift
@@ -1,18 +1,60 @@
 import SwiftUI
 
-public struct EnumParameterView<Value: CaseIterable & CustomDebugStringConvertible & Hashable>: ParameterView {
-    let key: String
-    @Binding var value: Value
+public struct EnumParameter {
+    public typealias EnumType = CaseIterable & CustomDebugStringConvertible & Hashable
     
-    public init(key: String, value: Binding<Value>) {
+    var current: AnyHashable
+    let cases: [String: AnyHashable]
+    
+    init<E: EnumType>(value: E) {
+        self.current = value
+        self.cases = Dictionary(uniqueKeysWithValues: E.allCases.map {
+            ($0.debugDescription, $0)
+        })
+    }
+    
+    func value<E>() -> E? {
+        return current as? E
+    }
+}
+
+
+public extension Exhibit.Context {
+    func parameter<E: EnumParameter.EnumType>(name: String, defaultValue: E) -> E {
+        let parameter: EnumParameter = parameter(
+            name: name,
+            defaultValue: EnumParameter(value: defaultValue)
+        )
+        
+        return parameter.current as! E
+    }
+    
+    func parameter<E: EnumParameter.EnumType>(name: String, defaultValue: E) -> Binding<E> {
+        let parameter: Binding<EnumParameter> = parameter(
+            name: name,
+            defaultValue: EnumParameter(value: defaultValue)
+        )
+        
+        return Binding(
+            get: { parameter.wrappedValue.current as! E },
+            set: { parameter.wrappedValue.current = $0 }
+        )
+    }
+}
+
+public struct EnumParameterView: ParameterView {
+    let key: String
+    @Binding var value: EnumParameter
+    
+    public init(key: String, value: Binding<EnumParameter>) {
         self.key = key
         _value = value
     }
     
     public var body: some View {
-        Picker(key, selection: $value) {
-            ForEach(Array(Value.allCases), id: \.debugDescription) { option in
-                Text(option.debugDescription).tag(option)
+        Picker(key, selection: $value.current) {
+            ForEach(value.cases.sorted(by: keyAscending), id: \.0) { (key, value) in
+                Text(key).tag(value)
             }
         }
     }


### PR DESCRIPTION
Adds a general solution for debuggable enum parameters.

Requires the enum conforms to `CaseIterable, CustomDebugStringConvertible, Hashable`.

Shows a picker for selecting enum options in the debug menu.

![Kapture 2022-03-07 at 10 24 41](https://user-images.githubusercontent.com/609274/157094905-806e76ff-ef02-47bf-914d-3b6a724a52a4.gif)

