### PR TITLE
Fix bug where accessibility change resets context

### DIFF
--- a/Example/Exhibition.generated.swift
+++ b/Example/Exhibition.generated.swift
@@ -4,6 +4,8 @@ import Exhibition
 import SwiftUI
 
 public struct Exhibition: View {
+    public init() {}
+    
     public var body: some View {
         NavigationView {
             ExhibitListView(

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -39,6 +39,7 @@ public struct AnyExhibit {
     let name: String
     let section: String
     let content: (Context) -> AnyView
+    let context = Context()
     
     init<Content: View, Layout: View>(_ exhibit: Exhibit<Content>, layout: @escaping (Content) -> Layout) {
         self.name = exhibit.name
@@ -58,6 +59,11 @@ extension AnyExhibit: Identifiable {
 struct AnyExhibitView: View {
     let exhibit: AnyExhibit
     @ObservedObject var context: Context
+    
+    init(exhibit: AnyExhibit) {
+        self.exhibit = exhibit
+        self.context = exhibit.context
+    }
     
     var body: some View {
         exhibit.content(context)

--- a/Sources/Exhibition/ExhibitListView.swift
+++ b/Sources/Exhibition/ExhibitListView.swift
@@ -79,8 +79,7 @@ public struct ExhibitListView: View {
     }
     
     private func debuggable(_ exhibit: AnyExhibit) -> some View {
-        let context = Context()
-        return AnyExhibitView(exhibit: exhibit, context: context)
+        return AnyExhibitView(exhibit: exhibit)
             .toolbar {
                 ToolbarItem {
                     Button {
@@ -92,7 +91,7 @@ public struct ExhibitListView: View {
             }
             .sheet(isPresented: $exhibitDebugViewPresented) {
                 DebugView(
-                    context: context,
+                    context: exhibit.context,
                     preferredColorScheme: $preferredColorScheme,
                     layoutDirection: $layoutDirection
                 )


### PR DESCRIPTION
Resolves #51

Creates and stores the context on the `AnyExhibit` model before view body calculation. This ensures that when swiftUI re-runs the body, we maintain the context for each exhibit.

![Kapture 2022-03-07 at 12 33 43](https://user-images.githubusercontent.com/609274/157113509-19ab2e95-4be8-415a-84ab-8304009915f6.gif)
