### PR TITLE
Add detail to unknown parameter view

### DIFF
--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -65,14 +65,23 @@ struct DebugView: View {
         .preferredColorScheme(preferredColorScheme)
     }
     
-    private func parameterView(parameter: (key: String, value: Any)) -> AnyView? {
-        let view = parameterViews
+    @ViewBuilder private func parameterView(parameter: (key: String, value: Any)) -> some View {
+        if let view = possibleParameterView(parameter: parameter) {
+            view
+        } else {
+            UnknownParameterView(
+                key: parameter.key,
+                value: context.parameter(name: parameter.key, defaultValue: parameter.value)
+            )
+        }
+    }
+    
+    private func possibleParameterView(parameter: (key: String, value: Any)) -> AnyView? {
+        parameterViews
             .lazy
             .compactMap { parameterView in
                 parameterView(parameter.key, parameter.value, context)
             }
             .first
-        
-        return view ?? AnyView(Text(parameter.key))
     }
 }

--- a/Sources/Exhibition/ParameterViews/UnknownParameterView.swift
+++ b/Sources/Exhibition/ParameterViews/UnknownParameterView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+/// View displayed when a matching parameter view is not found.
+struct UnknownParameterView: ParameterView {
+    let key: String
+    @Binding var value: Any
+    
+    var body: some View {
+        Text("\(key): \(String(describing: type(of: value)))")
+    }
+}


### PR DESCRIPTION
Adds type details to fallback view for unknown parameter types.

Screenshot is by disabling built in parameter views to show output
![Screen Shot 2022-03-11 at 08 41 04](https://user-images.githubusercontent.com/609274/157917151-d3ed90b1-21f0-4d4b-9f53-deae986ba65d.png)
