### PR TITLE
Add Dynamic type size selector to debug

### DIFF
--- a/Sources/Exhibition/DebugView.swift
+++ b/Sources/Exhibition/DebugView.swift
@@ -6,6 +6,7 @@ struct DebugView: View {
     
     @Binding var preferredColorScheme: ColorScheme
     @Binding var layoutDirection: LayoutDirection
+    @Binding var contentSizeCategory: ContentSizeCategory
     
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.parameterViews) var parameterViews
@@ -22,6 +23,12 @@ struct DebugView: View {
                     Picker("Layout Direction", selection: $layoutDirection) {
                         Text("Left to Right").tag(LayoutDirection.leftToRight)
                         Text("Right to Left").tag(LayoutDirection.rightToLeft)
+                    }
+                    
+                    Picker("Content Size Category", selection: $contentSizeCategory) {
+                        ForEach(ContentSizeCategory.allCases, id: \.self) { size in
+                            Text(String(describing: size)).tag(size)
+                        }
                     }
                 } header: {
                     Text("Accessibility")

--- a/Sources/Exhibition/ExhibitListView.swift
+++ b/Sources/Exhibition/ExhibitListView.swift
@@ -12,7 +12,8 @@ public struct ExhibitListView: View {
     // MARK: Accessibility
     @State var preferredColorScheme: ColorScheme = .light
     @State var layoutDirection: LayoutDirection = .leftToRight
-    
+    @State var contentSizeCategory: ContentSizeCategory = .medium
+        
     private var sections: [String: [AnyExhibit]] {
         Dictionary(grouping: searchResults, by: \.section)
     }
@@ -71,15 +72,17 @@ public struct ExhibitListView: View {
             DebugView(
                 context: .init(),
                 preferredColorScheme: $preferredColorScheme,
-                layoutDirection: $layoutDirection
+                layoutDirection: $layoutDirection,
+                contentSizeCategory: $contentSizeCategory
             )
         }
         .preferredColorScheme(preferredColorScheme)
         .environment(\.layoutDirection, layoutDirection)
     }
     
-    private func debuggable(_ exhibit: AnyExhibit) -> some View {
-        return AnyExhibitView(exhibit: exhibit)
+    @ViewBuilder private func debuggable(_ exhibit: AnyExhibit) -> some View {
+        AnyExhibitView(exhibit: exhibit)
+            .environment(\.sizeCategory, contentSizeCategory)
             .toolbar {
                 ToolbarItem {
                     Button {
@@ -93,7 +96,8 @@ public struct ExhibitListView: View {
                 DebugView(
                     context: exhibit.context,
                     preferredColorScheme: $preferredColorScheme,
-                    layoutDirection: $layoutDirection
+                    layoutDirection: $layoutDirection,
+                    contentSizeCategory: $contentSizeCategory
                 )
             }
             .parameterView(StringParameterView.self)


### PR DESCRIPTION
Resolves #12

Note: This only affects the content size of the exhibits themselves.
Placing the environment change higher up was causing navigation to reset, and undesirable UI changes in the list and debug view.

![Kapture 2022-03-17 at 14 32 17](https://user-images.githubusercontent.com/609274/158898763-1be3b970-8de9-4b56-8b83-663eea5e5d4a.gif)

