### PR TITLE
Fix layout direction switcher

### DIFF
--- a/Sources/Exhibition/ExhibitListView.swift
+++ b/Sources/Exhibition/ExhibitListView.swift
@@ -75,11 +75,11 @@ public struct ExhibitListView: View {
             )
         }
         .preferredColorScheme(preferredColorScheme)
-        .environment(\.layoutDirection, layoutDirection)
     }
     
     private func debuggable(_ exhibit: AnyExhibit) -> some View {
         return AnyExhibitView(exhibit: exhibit)
+            .environment(\.layoutDirection, layoutDirection)
             .toolbar {
                 ToolbarItem {
                     Button {


### PR DESCRIPTION
Setting the environment up higher was not affecting the actual exhibit displayed. Moving this keeps the main navigation and debug view intact as normal while adjusting the direction of the exhibits.