### PR TITLE
Remove `Exhibit` type, use protocol requirements to build exhibit

### DIFF
--- a/Example/CustomButton.swift
+++ b/Example/CustomButton.swift
@@ -23,10 +23,10 @@ struct CustomButton_Previews: ExhibitProvider, PreviewProvider {
     }
     
     static var previews: some View {
-        exhibit.preview()
+        exhibitPreview()
             .previewLayout(.sizeThatFits)
         
-        exhibit.preview(parameters: ["title": "Other"])
+        exhibitPreview(parameters: ["title": "Other"])
             .previewLayout(.sizeThatFits)
     }
 }

--- a/Example/CustomButton.swift
+++ b/Example/CustomButton.swift
@@ -13,7 +13,9 @@ struct CustomButton: View {
 }
 
 struct CustomButton_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit = Exhibit(name: "CustomButton") { context in
+    static var exhibitName: String = "CustomButton"
+    
+    static func exhibitContent(context: Context) -> some View {
         CustomButton(
             title: context.parameter(name: "title", defaultValue: "Title"),
             action: context.parameter(name: "action")

--- a/Example/CustomDatePicker.swift
+++ b/Example/CustomDatePicker.swift
@@ -11,10 +11,10 @@ struct CustomDatePicker: View {
 }
 
 struct CustomDatePicker_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit = Exhibit(
-        name: "CustomDatePicker",
-        section: "Pickers"
-    ) { context in
+    static var exhibitName: String = "CustomDatePicker"
+    static var exhibitSection: String = "Pickers"
+    
+    static func exhibitContent(context: Context) -> some View {
         CustomDatePicker(
             title: context.parameter(name: "title", defaultValue: "Title"),
             date: context.parameter(name: "date")

--- a/Example/CustomSegmentedControl.swift
+++ b/Example/CustomSegmentedControl.swift
@@ -26,10 +26,10 @@ struct CustomSegmentedControl: View {
 }
 
 struct CustomSegmentedControl_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit: Exhibit = Exhibit(
-        name: "CustomSegmentedControl",
-        section: "Pickers"
-    ) { context in
+    static var exhibitName: String = "CustomSegmentedControl"
+    static var exhibitSection: String = "Pickers"
+    
+    static func exhibitContent(context: Context) -> some View {
         CustomSegmentedControl(
             title: context.parameter(name: "title", defaultValue: "Title"),
             selection: context.parameter(name: "selection", defaultValue: .first)

--- a/Example/CustomTextField.swift
+++ b/Example/CustomTextField.swift
@@ -38,7 +38,9 @@ struct CustomTextField: View {
 }
 
 struct CustomTextField_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit = Exhibit(name: "CustomTextField") { context in
+    static var exhibitName: String = "CustomTextField"
+    
+    static func exhibitContent(context: Context) -> some View {
         CustomTextField(
             doublePlaceholder: context.parameter(name: "doublePlaceholder", defaultValue: "0.0"),
             floatPlaceholder: context.parameter(name: "floatPlaceholder", defaultValue: "0.0"),

--- a/Example/CustomTextField.swift
+++ b/Example/CustomTextField.swift
@@ -50,10 +50,10 @@ struct CustomTextField_Previews: ExhibitProvider, PreviewProvider {
     }
     
     static var previews: some View {
-        exhibit.preview()
+        exhibitPreview()
             .previewLayout(.sizeThatFits)
         
-        exhibit.preview(parameters: ["floatValue": 1.0])
+        exhibitPreview(parameters: ["floatValue": 1.0])
             .previewLayout(.sizeThatFits)
     }
 }

--- a/Example/CustomToggle.swift
+++ b/Example/CustomToggle.swift
@@ -11,7 +11,9 @@ struct CustomToggle: View {
 }
 
 struct CustomToggle_Previews: ExhibitProvider, PreviewProvider {
-    static var exhibit = Exhibit(name: "CustomToggle") { context in
+    static var exhibitName: String = "CustomToggle"
+    
+    static func exhibitContent(context: Context) -> CustomToggle {
         CustomToggle(
             title: context.parameter(name: "title", defaultValue: "Title"),
             isOn: context.parameter(name: "isOn")

--- a/Example/CustomToggle.swift
+++ b/Example/CustomToggle.swift
@@ -20,7 +20,7 @@ struct CustomToggle_Previews: ExhibitProvider, PreviewProvider {
         )
     }
     
-    static func exhibitLayout(content: CustomToggle) -> some View {
+    static func exhibitLayout(content: AnyView) -> some View {
         content.padding()
     }
 }

--- a/Example/CustomToggle.swift
+++ b/Example/CustomToggle.swift
@@ -13,14 +13,14 @@ struct CustomToggle: View {
 struct CustomToggle_Previews: ExhibitProvider, PreviewProvider {
     static var exhibitName: String = "CustomToggle"
     
-    static func exhibitContent(context: Context) -> CustomToggle {
+    static func exhibitContent(context: Context) -> some View {
         CustomToggle(
             title: context.parameter(name: "title", defaultValue: "Title"),
             isOn: context.parameter(name: "isOn")
         )
     }
     
-    static func exhibitLayout(_ content: CustomToggle) -> some View {
+    static func exhibitLayout(content: CustomToggle) -> some View {
         content.padding()
     }
 }

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Inspired by [Storybook](https://storybook.js.org/) and [Showkase](https://github
     import Exhibition
     
     struct Foo_Previews: ExhibitProvider, PreviewProvider {
-        static var exhibit = Exhibit(
-            name: "Foo",
-            section: "Bar"
-        ) { context in
+        static var exhibitName: String = "Foo"
+        static var exhibitSection: String = "Bar"
+        
+        static func exhibitContent(context: Context) -> some View {
             Foo(
                 title: context.parameter(name: "title", defaultValue: "Title"),
                 content: context.parameter(name: "content")
@@ -42,7 +42,7 @@ If you would like your exhibit to have some custom layout, there is an optional 
 Here is an example of embeding the exhibit within a `List`:
 
 ```swift
-static func exhibitLayout(_ content: Foo) -> some View {
+static func exhibitLayout(content: Foo) -> some View {
     List {
         content
     }
@@ -67,7 +67,7 @@ struct CustomLayout<Content: View>: View {
     }
 }
 
-static func exhibitLayout(_ content: Foo) -> some View {
+static func exhibitLayout(content: Foo) -> some View {
     CustomLayout(content: content)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you would like your exhibit to have some custom layout, there is an optional 
 Here is an example of embeding the exhibit within a `List`:
 
 ```swift
-static func exhibitLayout(content: Foo) -> some View {
+static func exhibitLayout(content: AnyView) -> some View {
     List {
         content
     }
@@ -67,7 +67,7 @@ struct CustomLayout<Content: View>: View {
     }
 }
 
-static func exhibitLayout(content: Foo) -> some View {
+static func exhibitLayout(content: AnyView) -> some View {
     CustomLayout(content: content)
 }
 ```

--- a/Sources/Exhibition/AnyExhibit.swift
+++ b/Sources/Exhibition/AnyExhibit.swift
@@ -11,7 +11,7 @@ public struct AnyExhibit {
         self.name = provider.exhibitName
         self.section = provider.exhibitSection
         self.content = { context in
-            AnyView(provider.exhibitLayout(content: provider.exhibitContent(context: context)))
+            AnyView(provider.exhibitLayout(content: AnyView(provider.exhibitContent(context: context))))
         }
     }
 }

--- a/Sources/Exhibition/AnyExhibit.swift
+++ b/Sources/Exhibition/AnyExhibit.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Wrapper for an `ExhibitProvider` erasing the Content and Layout types.
 public struct AnyExhibit {
     let name: String
     let section: String
@@ -10,7 +11,7 @@ public struct AnyExhibit {
         self.name = provider.exhibitName
         self.section = provider.exhibitSection
         self.content = { context in
-            AnyView(provider.exhibitLayout(provider.exhibitContent(context: context)))
+            AnyView(provider.exhibitLayout(content: provider.exhibitContent(context: context)))
         }
     }
 }

--- a/Sources/Exhibition/Exhibit.swift
+++ b/Sources/Exhibition/Exhibit.swift
@@ -1,51 +1,16 @@
 import SwiftUI
 
-public struct Exhibit<Content: View> {
- 
-    let name: String
-    let section: String
-    let content: (Context) -> Content
-    
-    public init(
-        name: String,
-        section: String = "",
-        @ViewBuilder builder: @escaping (Context) -> Content
-    ) {
-        self.name = name
-        self.section = section
-        self.content = builder
-    }
-}
-
-extension Exhibit {
-    @ViewBuilder public func preview(parameters: [String: Any] = [:]) -> some View {
-        ExhibitView(
-            exhibit: self,
-            context: Context(parameters: parameters)
-        )
-    }
-}
-
-struct ExhibitView<Content: View>: View {
-    let exhibit: Exhibit<Content>
-    @ObservedObject var context: Context
-    
-    var body: some View {
-        exhibit.content(context)
-    }
-}
-
 public struct AnyExhibit {
     let name: String
     let section: String
     let content: (Context) -> AnyView
     let context = Context()
     
-    init<Content: View, Layout: View>(_ exhibit: Exhibit<Content>, layout: @escaping (Content) -> Layout) {
-        self.name = exhibit.name
-        self.section = exhibit.section
+    init<P: ExhibitProvider>(provider: P.Type) {
+        self.name = provider.exhibitName
+        self.section = provider.exhibitSection
         self.content = { context in
-            AnyView(layout(exhibit.content(context)))
+            AnyView(provider.exhibitLayout(provider.exhibitContent(context: context)))
         }
     }
 }

--- a/Sources/Exhibition/ExhibitListView.swift
+++ b/Sources/Exhibition/ExhibitListView.swift
@@ -120,14 +120,20 @@ public struct ExhibitListView: View {
 
 struct ExhibitListView_Previews: PreviewProvider {
     struct First: ExhibitProvider {
-        static let exhibit = Exhibit(name: "Text", section: "Section 1") { context in
-            Text(context.parameter(name: "Content", defaultValue: "Text"))
+        static var exhibitName: String = "Text"
+        static var exhibitSection: String = "Section 1"
+        
+        static func exhibitContent(context: Context) -> some View {
+            Text(context.parameter(name: "Content", defaultValue: "text"))
         }
     }
     
     struct Second: ExhibitProvider {
-        static let exhibit = Exhibit(name: "Text", section: "Section 1") { context in
-            Text(context.parameter(name: "Content", defaultValue: "Text"))
+        static var exhibitName: String = "Text"
+        static var exhibitSection: String = "Section 1"
+        
+        static func exhibitContent(context: Context) -> some View {
+            Text(context.parameter(name: "Content", defaultValue: "text"))
         }
     }
     

--- a/Sources/Exhibition/ExhibitProvider.swift
+++ b/Sources/Exhibition/ExhibitProvider.swift
@@ -7,14 +7,17 @@ public protocol ExhibitProvider {
     static var exhibitName: String { get }
     static var exhibitSection: String { get }
     
-    static func exhibitContent(context: Context) -> Content
+    @ViewBuilder static func exhibitContent(context: Context) -> Content
     
-    static func exhibitLayout(content: Content) -> Layout
+    @ViewBuilder static func exhibitLayout(content: AnyView) -> Layout
 }
 
 public extension ExhibitProvider {
     static var exhibitSection: String { "" }
     
+    @ViewBuilder static func exhibitLayout(content: AnyView) -> some View {
+        content
+    }
     
     @ViewBuilder static func exhibitPreview(parameters: [String: Any] = [:]) -> some View {
         ExhibitPreview(
@@ -30,12 +33,6 @@ public extension ExhibitProvider {
     
     static var anyExhibit: AnyExhibit {
         AnyExhibit(provider: self)
-    }
-}
-
-public extension ExhibitProvider where Content == Layout {
-    static func exhibitLayout(content: Content) -> Layout {
-        content
     }
 }
 

--- a/Sources/Exhibition/ExhibitProvider.swift
+++ b/Sources/Exhibition/ExhibitProvider.swift
@@ -15,23 +15,35 @@ public protocol ExhibitProvider {
 public extension ExhibitProvider {
     static var exhibitSection: String { "" }
     
-    static var exhibit: Exhibit<Content> {
-        Exhibit(name: exhibitName, section: exhibitSection, builder: exhibitContent)
+    
+    @ViewBuilder static func exhibitPreview(parameters: [String: Any] = [:]) -> some View {
+        ExhibitPreview(
+            builder: exhibitContent,
+            context: Context(parameters: parameters)
+        )
     }
     
     static var previews: some View {
-        Exhibit(name: exhibitName, section: exhibitSection, builder: exhibitContent)
-            .preview()
+        exhibitPreview()
             .previewLayout(.sizeThatFits)
     }
     
     static var anyExhibit: AnyExhibit {
-        AnyExhibit(exhibit, layout: exhibitLayout)
+        AnyExhibit(provider: self)
     }
 }
 
 public extension ExhibitProvider where Content == Layout {
     static func exhibitLayout(_ content: Content) -> Layout {
         content
+    }
+}
+
+struct ExhibitPreview<Content: View>: View {
+    let builder: (Context) -> Content
+    @ObservedObject var context: Context
+    
+    var body: some View {
+        builder(context)
     }
 }

--- a/Sources/Exhibition/ExhibitProvider.swift
+++ b/Sources/Exhibition/ExhibitProvider.swift
@@ -4,14 +4,23 @@ public protocol ExhibitProvider {
     associatedtype Content: View
     associatedtype Layout: View
     
-    static var exhibit: Exhibit<Content> { get }
+    static var exhibitName: String { get }
+    static var exhibitSection: String { get }
+    
+    static func exhibitContent(context: Context) -> Content
     
     static func exhibitLayout(_ content: Content) -> Layout
 }
 
 public extension ExhibitProvider {
+    static var exhibitSection: String { "" }
+    
+    static var exhibit: Exhibit<Content> {
+        Exhibit(name: exhibitName, section: exhibitSection, builder: exhibitContent)
+    }
+    
     static var previews: some View {
-        exhibit
+        Exhibit(name: exhibitName, section: exhibitSection, builder: exhibitContent)
             .preview()
             .previewLayout(.sizeThatFits)
     }

--- a/Sources/Exhibition/ExhibitProvider.swift
+++ b/Sources/Exhibition/ExhibitProvider.swift
@@ -9,7 +9,7 @@ public protocol ExhibitProvider {
     
     static func exhibitContent(context: Context) -> Content
     
-    static func exhibitLayout(_ content: Content) -> Layout
+    static func exhibitLayout(content: Content) -> Layout
 }
 
 public extension ExhibitProvider {
@@ -34,7 +34,7 @@ public extension ExhibitProvider {
 }
 
 public extension ExhibitProvider where Content == Layout {
-    static func exhibitLayout(_ content: Content) -> Layout {
+    static func exhibitLayout(content: Content) -> Layout {
         content
     }
 }


### PR DESCRIPTION
Refactors `ExhibitProvider` to have separate getters for `name`, `section`, and `exhibit`.

Benefits:
- Consistent API for exhibit content and layout
- Detachment of Layout to Content types allows for use of view modifiers directly.
- autocomplete more reliable and output code easier to read.

Best way to review API changes is to look at the rich diff for `README.md`